### PR TITLE
✨ [Feat] 기본 도메인 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	runtimeOnly 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/docs/NOFFICE-erd.md
+++ b/docs/NOFFICE-erd.md
@@ -1,0 +1,112 @@
+# Noffice-mermaid ERD
+
+```mermaid
+---
+title : NOFFICE-ERD (ver 1.0.0)
+---
+erDiagram
+    MEMBER {
+        bigint id PK
+        varchar name
+        varchar alias
+        AuthProvider auth_provider
+        varchar profile_image_url
+    }
+
+    ORGANIZATION {
+        bigint id PK
+        varchar name
+        timestamp end_date
+        varchar profile_image_url
+    }
+
+    MEMBER ||--|{ ORGANIZATION_MEMBER : belongs
+    ORGANIZATION ||--|{ ORGANIZATION_MEMBER : belongs
+    ORGANIZATION_MEMBER {
+        bigint id PK
+        bigint organization_id FK
+        bigint member_id FK
+        OragnizationRole role
+    }
+
+    MEMBER ||--o{ FCM_NOTIFICATION_TOKEN : has
+    FCM_NOTIFICATION_TOKEN {
+        bigint id PK
+        bigint member_id FK
+        varchar device_id
+        varchar fcm_token
+    }
+
+    MEMBER ||--|{ AUTH : authenticate
+    AUTH {
+        varchar id PK
+        bigint member_id FK
+        varchar refresh_token
+        AuthProvider auth_provider
+    }
+
+    MEMBER ||--o{ READ_STATUS : checks
+    READ_STATUS {
+        bigint id PK
+        bigint announce_id FK
+        bigint member_id FK
+    }
+
+    ORGANIZATION ||--o| PROMOTION : "uses"
+    PROMOTION {
+        bigint id PK
+        varchar code
+        varchar promotion_image_url
+        boolean used
+    }
+
+    ORGANIZATION ||--|{ ORGANIZATION_CATEGORY : has
+    CATEGORY ||--|{ ORGANIZATION_CATEGORY : categorized
+    ORGANIZATION_CATEGORY {
+        bigint id PK
+        bigint organization_id FK
+        bigint category_id FK
+    }
+
+    CATEGORY {
+        bigint id PK
+        varchar name
+    }
+
+    ORGANIZATION ||--o{ ANNOUNCE : "has"
+    ANNOUNCE {
+        bigint id PK
+        bigint creator_id FK
+        bigint organization_id FK
+        varchar title
+        text content
+        varchar cover_image_url
+        varchar place_link_title
+        varchar place_link_url
+        timestamp opening_time
+        timestamp closing_time
+        timestamp notification_time
+    }
+
+    MEMBER ||--o{ TASK_STATUS : records
+    TASKS ||--o{ TASK_STATUS : updates
+    TASK_STATUS {
+        bigint id PK
+        bigint task_id FK
+        bigint member_id FK
+        boolean checked
+    }
+
+    ANNOUNCE ||--o{ TASKS : has
+    TASKS {
+        bigint id PK
+        bigint announce_id FK
+        bigint organization_id FK
+        varchar content
+    }
+
+    BASETIMEENTITY {
+        timestamp created_at
+        timestamp updated_at
+    }
+```

--- a/docs/NOFFICE-erd.md
+++ b/docs/NOFFICE-erd.md
@@ -9,59 +9,17 @@ erDiagram
         bigint id PK
         varchar name
         varchar alias
-        AuthProvider auth_provider
-        varchar profile_image_url
+        varchar profile_image
     }
 
     ORGANIZATION {
         bigint id PK
         varchar name
-        timestamp end_date
-        varchar profile_image_url
+        timestamp end_at
+        varchar profile_image
     }
-
-    MEMBER ||--|{ ORGANIZATION_MEMBER : belongs
-    ORGANIZATION ||--|{ ORGANIZATION_MEMBER : belongs
-    ORGANIZATION_MEMBER {
-        bigint id PK
-        bigint organization_id FK
-        bigint member_id FK
-        OragnizationRole role
-    }
-
-    MEMBER ||--o{ FCM_NOTIFICATION_TOKEN : has
-    FCM_NOTIFICATION_TOKEN {
-        bigint id PK
-        bigint member_id FK
-        varchar device_id
-        varchar fcm_token
-    }
-
-    MEMBER ||--|{ AUTH : authenticate
-    AUTH {
-        varchar id PK
-        bigint member_id FK
-        varchar refresh_token
-        AuthProvider auth_provider
-    }
-
-    MEMBER ||--o{ READ_STATUS : checks
-    READ_STATUS {
-        bigint id PK
-        bigint announce_id FK
-        bigint member_id FK
-    }
-
-    ORGANIZATION ||--o| PROMOTION : "uses"
-    PROMOTION {
-        bigint id PK
-        varchar code
-        varchar promotion_image_url
-        boolean used
-    }
-
-    ORGANIZATION ||--|{ ORGANIZATION_CATEGORY : has
-    CATEGORY ||--|{ ORGANIZATION_CATEGORY : categorized
+    ORGANIZATION ||--|{ ORGANIZATION_CATEGORY: has
+    CATEGORY ||--|{ ORGANIZATION_CATEGORY: categorized
     ORGANIZATION_CATEGORY {
         bigint id PK
         bigint organization_id FK
@@ -73,23 +31,65 @@ erDiagram
         varchar name
     }
 
-    ORGANIZATION ||--o{ ANNOUNCE : "has"
-    ANNOUNCE {
+    MEMBER ||--|{ ORGANIZATION_MEMBER: belongs
+    ORGANIZATION ||--|{ ORGANIZATION_MEMBER: belongs
+    ORGANIZATION_MEMBER {
+        bigint id PK
+        bigint organization_id FK
+        bigint member_id FK
+        OragnizationRole role
+    }
+
+    FCM_NOTIFICATION_TOKEN }o--|| MEMBER: "has"
+    FCM_NOTIFICATION_TOKEN {
+        bigint id PK
+        bigint member_id FK
+        varchar device_id
+        varchar fcm_token
+    }
+
+    MEMBER ||--|| REFRESH_TOKEN: authenticate
+    REFRESH_TOKEN {
+        varchar id PK
+        bigint member_id FK
+        varchar refresh_token
+        SocialAuthProvider auth_provider
+        timestamp expired_date_time
+    }
+
+    MEMBER ||--o{ MEMBER_READ_STATUS: checks
+    MEMBER_READ_STATUS {
+        bigint id PK
+        bigint announce_id FK
+        bigint member_id FK
+        boolean checked
+    }
+
+    ORGANIZATION ||--o| PROMOTION: "uses"
+    PROMOTION {
+        bigint id PK
+        varchar code
+        varchar promotion_image_url
+        boolean used
+    }
+
+    ORGANIZATION ||--o{ ANNOUNCEMENT: "has"
+    ANNOUNCEMENT {
         bigint id PK
         bigint creator_id FK
         bigint organization_id FK
         varchar title
         text content
-        varchar cover_image_url
+        varchar cover_image
         varchar place_link_title
         varchar place_link_url
-        timestamp opening_time
-        timestamp closing_time
-        timestamp notification_time
+        timestamp start_at
+        timestamp end_at
+        timestamp notice_at
     }
 
-    MEMBER ||--o{ TASK_STATUS : records
-    TASKS ||--o{ TASK_STATUS : updates
+    MEMBER ||--o{ TASK_STATUS: records
+    TASK ||--o{ TASK_STATUS: updates
     TASK_STATUS {
         bigint id PK
         bigint task_id FK
@@ -97,8 +97,8 @@ erDiagram
         boolean checked
     }
 
-    ANNOUNCE ||--o{ TASKS : has
-    TASKS {
+    ANNOUNCEMENT ||--o{ TASK: has
+    TASK {
         bigint id PK
         bigint announce_id FK
         bigint organization_id FK

--- a/src/main/java/com/notitime/noffice/NofficeApplication.java
+++ b/src/main/java/com/notitime/noffice/NofficeApplication.java
@@ -2,8 +2,10 @@ package com.notitime.noffice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class NofficeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/notitime/noffice/domain/Announcement.java
+++ b/src/main/java/com/notitime/noffice/domain/Announcement.java
@@ -1,0 +1,44 @@
+package com.notitime.noffice.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Announcement extends BaseTimeEntity {
+
+	@Id
+	private Long id;
+
+	private String title;
+
+	private String content;
+
+	private String coverImage;
+
+	private String place_link_title;
+
+	private String place_link_url;
+
+	private LocalDateTime startAt;
+
+	private LocalDateTime endAt;
+
+	private LocalDateTime noticeAt;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "creator_id")
+	private Member member;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "organization_id")
+	private Organization organization;
+}

--- a/src/main/java/com/notitime/noffice/domain/BaseTimeEntity.java
+++ b/src/main/java/com/notitime/noffice/domain/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package com.notitime.noffice.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+	@CreatedDate
+	@Column(updatable = false)
+	private LocalDateTime createdDate;
+
+	@LastModifiedDate
+	private LocalDateTime lastModifiedDate;
+}

--- a/src/main/java/com/notitime/noffice/domain/Category.java
+++ b/src/main/java/com/notitime/noffice/domain/Category.java
@@ -1,0 +1,20 @@
+package com.notitime.noffice.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Category {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	private String name;
+}

--- a/src/main/java/com/notitime/noffice/domain/FcmNotificationToken.java
+++ b/src/main/java/com/notitime/noffice/domain/FcmNotificationToken.java
@@ -1,0 +1,30 @@
+package com.notitime.noffice.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class FcmNotificationToken {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	private String fcmToken;
+
+	private String deviceId;
+}

--- a/src/main/java/com/notitime/noffice/domain/Member.java
+++ b/src/main/java/com/notitime/noffice/domain/Member.java
@@ -1,0 +1,31 @@
+package com.notitime.noffice.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Member extends BaseTimeEntity {
+	
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String name;
+
+	private String alias;
+
+	private String profileImage;
+
+	@OneToMany(mappedBy = "member")
+	private final List<OrganizationMember> organizations = new ArrayList<>();
+}

--- a/src/main/java/com/notitime/noffice/domain/MemberReadStatus.java
+++ b/src/main/java/com/notitime/noffice/domain/MemberReadStatus.java
@@ -1,0 +1,34 @@
+package com.notitime.noffice.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member_read_status")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MemberReadStatus {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "announcement_id")
+	private Announcement announcement;
+
+	private Boolean checked;
+}

--- a/src/main/java/com/notitime/noffice/domain/Organization.java
+++ b/src/main/java/com/notitime/noffice/domain/Organization.java
@@ -1,0 +1,25 @@
+package com.notitime.noffice.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Organization extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	private String name;
+
+	private LocalDateTime endAt;
+
+	private String profileImage;
+}

--- a/src/main/java/com/notitime/noffice/domain/OrganizationCategory.java
+++ b/src/main/java/com/notitime/noffice/domain/OrganizationCategory.java
@@ -1,0 +1,28 @@
+package com.notitime.noffice.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class OrganizationCategory {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "organization_id")
+	private Organization organization;
+
+	@ManyToOne
+	@JoinColumn(name = "category_id")
+	private Category category;
+}

--- a/src/main/java/com/notitime/noffice/domain/OrganizationMember.java
+++ b/src/main/java/com/notitime/noffice/domain/OrganizationMember.java
@@ -1,0 +1,31 @@
+package com.notitime.noffice.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class OrganizationMember {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	private OrganizationRole role;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "organization_id")
+	private Organization organization;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+}

--- a/src/main/java/com/notitime/noffice/domain/OrganizationRole.java
+++ b/src/main/java/com/notitime/noffice/domain/OrganizationRole.java
@@ -1,0 +1,5 @@
+package com.notitime.noffice.domain;
+
+public enum OrganizationRole {
+	ADMIN, LEADER, PARTICIPANT
+}

--- a/src/main/java/com/notitime/noffice/domain/Promotion.java
+++ b/src/main/java/com/notitime/noffice/domain/Promotion.java
@@ -1,0 +1,24 @@
+package com.notitime.noffice.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Promotion {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	private String code;
+
+	private String promotionImage;
+
+	private Boolean isUsed;
+}

--- a/src/main/java/com/notitime/noffice/domain/RefreshToken.java
+++ b/src/main/java/com/notitime/noffice/domain/RefreshToken.java
@@ -1,0 +1,36 @@
+package com.notitime.noffice.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Table(name = "refresh_token")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class RefreshToken {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@OneToOne
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	SocialAuthProvider provider;
+
+	// TODO : UUID로 변경
+	private String refreshToken;
+
+	private LocalDateTime expiredDateTime;
+}

--- a/src/main/java/com/notitime/noffice/domain/SocialAuthProvider.java
+++ b/src/main/java/com/notitime/noffice/domain/SocialAuthProvider.java
@@ -1,0 +1,5 @@
+package com.notitime.noffice.domain;
+
+public enum SocialAuthProvider {
+	GOOGLE, APPLE
+}

--- a/src/main/java/com/notitime/noffice/domain/Task.java
+++ b/src/main/java/com/notitime/noffice/domain/Task.java
@@ -1,0 +1,25 @@
+package com.notitime.noffice.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Task {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private Long announceId;
+
+	private Long organizationId;
+
+	private String content;
+}

--- a/src/main/java/com/notitime/noffice/domain/TaskStatus.java
+++ b/src/main/java/com/notitime/noffice/domain/TaskStatus.java
@@ -1,0 +1,30 @@
+package com.notitime.noffice.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TaskStatus {
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	private Boolean checked;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "task_id")
+	private Task task;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=noffice

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb # DB 접속 URL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: true


### PR DESCRIPTION
## 🚀 Related Issue

close #5 

## 📌 Tasks

- 기본 도메인을 구현하였습니다.
- `docs` 폴더에 erd 문서를 구현해두었습니다. remark와 동일합니다.
- 로컬 테스트 용으로 H2 database를 붙였는데, 이후 클라우드로 이관 시 저장 경로를 조정합니다.

## 📝 Details

- `M:N` 관계를 가지는 `Organization`, `Category`, `Member` 의 경우 연결 테이블을 엔티티로 승격하여 취급합니다.
- WAS에서 발행하는 JWT `RefreshToken`의 경우 OAuth를 통해 발급되는 토큰에 의해 생성될 수 있도록 앱 내에서 사용하는 리프레시 토큰만 저장합니다.

## 📚 Remarks
```mermaid
erDiagram
    MEMBER {
        bigint id PK
        varchar name
        varchar alias
        varchar profile_image
    }

    ORGANIZATION {
        bigint id PK
        varchar name
        timestamp end_at
        varchar profile_image
    }
    ORGANIZATION ||--|{ ORGANIZATION_CATEGORY: has
    CATEGORY ||--|{ ORGANIZATION_CATEGORY: categorized
    ORGANIZATION_CATEGORY {
        bigint id PK
        bigint organization_id FK
        bigint category_id FK
    }

    CATEGORY {
        bigint id PK
        varchar name
    }

    MEMBER ||--|{ ORGANIZATION_MEMBER: belongs
    ORGANIZATION ||--|{ ORGANIZATION_MEMBER: belongs
    ORGANIZATION_MEMBER {
        bigint id PK
        bigint organization_id FK
        bigint member_id FK
        OragnizationRole role
    }

    FCM_NOTIFICATION_TOKEN }o--|| MEMBER: "has"
    FCM_NOTIFICATION_TOKEN {
        bigint id PK
        bigint member_id FK
        varchar device_id
        varchar fcm_token
    }

    MEMBER ||--|| REFRESH_TOKEN: authenticate
    REFRESH_TOKEN {
        varchar id PK
        bigint member_id FK
        varchar refresh_token
        SocialAuthProvider auth_provider
        timestamp expired_date_time
    }

    MEMBER ||--o{ MEMBER_READ_STATUS: checks
    MEMBER_READ_STATUS {
        bigint id PK
        bigint announce_id FK
        bigint member_id FK
        boolean checked
    }

    ORGANIZATION ||--o| PROMOTION: "uses"
    PROMOTION {
        bigint id PK
        varchar code
        varchar promotion_image_url
        boolean used
    }

    ORGANIZATION ||--o{ ANNOUNCEMENT: "has"
    ANNOUNCEMENT {
        bigint id PK
        bigint creator_id FK
        bigint organization_id FK
        varchar title
        text content
        varchar cover_image
        varchar place_link_title
        varchar place_link_url
        timestamp start_at
        timestamp end_at
        timestamp notice_at
    }

    MEMBER ||--o{ TASK_STATUS: records
    TASK ||--o{ TASK_STATUS: updates
    TASK_STATUS {
        bigint id PK
        bigint task_id FK
        bigint member_id FK
        boolean checked
    }

    ANNOUNCEMENT ||--o{ TASK: has
    TASK {
        bigint id PK
        bigint announce_id FK
        bigint organization_id FK
        varchar content
    }

    BASETIMEENTITY {
        timestamp created_at
        timestamp updated_at
    }
``` 