### PR TITLE
📝 [Docs] Swagger 문서화 의존성 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.0.4'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/notitime/noffice/global/config/SwaggerConfig.java
+++ b/src/main/java/com/notitime/noffice/global/config/SwaggerConfig.java
@@ -1,0 +1,28 @@
+package com.notitime.noffice.global.config;
+
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+	@Bean
+	public OpenAPI api() {
+		Server server = new Server().url("/");
+
+		return new OpenAPI()
+				.info(getSwaggerInfo())
+				.addServersItem(server);
+	}
+
+	private Info getSwaggerInfo() {
+		return new Info()
+				.title("NOFFICE API Docs")
+				.description("TEST: NOFFICE API Docs")
+				.version("v1.0");
+	}
+}


### PR DESCRIPTION
## 🚀 Related Issue

close: #6 

## 📌 Tasks

- Swagger api docs 의존성 설정

## 📝 Details

- 개발용 subdomain에서 접속 가능한 property 설정이 요구됩니다.

## 📚 Remarks

- 