### PR TITLE
✨ [Feat] 공통 응답 형식 구현

### DIFF
--- a/src/main/java/com/notitime/noffice/global/advice/NofficeResponseAdvice.java
+++ b/src/main/java/com/notitime/noffice/global/advice/NofficeResponseAdvice.java
@@ -7,8 +7,10 @@ import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
+@RestControllerAdvice(basePackages = "com.notitime.noffice")
 public class NofficeResponseAdvice implements ResponseBodyAdvice<Object> {
 	@Override
 	public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {

--- a/src/main/java/com/notitime/noffice/global/advice/NofficeResponseAdvice.java
+++ b/src/main/java/com/notitime/noffice/global/advice/NofficeResponseAdvice.java
@@ -1,0 +1,29 @@
+package com.notitime.noffice.global.advice;
+
+import com.notitime.noffice.global.response.NofficeResponse;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+public class NofficeResponseAdvice implements ResponseBodyAdvice<Object> {
+	@Override
+	public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+		return returnType.getParameterType() == NofficeResponse.class;
+	}
+
+	@Override
+	public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+	                              Class<? extends HttpMessageConverter<?>> selectedConverterType,
+	                              ServerHttpRequest request, ServerHttpResponse response) {
+
+		if (returnType.getParameterType() == NofficeResponse.class) {
+			HttpStatus status = HttpStatus.valueOf(((NofficeResponse<?>) body).getHttpStatus());
+			response.setStatusCode(status);
+		}
+		return body;
+	}
+}

--- a/src/main/java/com/notitime/noffice/global/response/BusinessErrorCode.java
+++ b/src/main/java/com/notitime/noffice/global/response/BusinessErrorCode.java
@@ -1,0 +1,17 @@
+package com.notitime.noffice.global.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum BusinessErrorCode implements ErrorCode {
+
+	BAD_REQUEST(HttpStatus.BAD_REQUEST, "NOF-400", "잘못된 요청입니다."),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "NOF-500", "서버 내부 오류가 발생했습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/notitime/noffice/global/response/BusinessSuccessCode.java
+++ b/src/main/java/com/notitime/noffice/global/response/BusinessSuccessCode.java
@@ -1,0 +1,20 @@
+package com.notitime.noffice.global.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum BusinessSuccessCode implements SuccessCode {
+
+	OK(HttpStatus.OK, "NOF-200", "요청이 성공했습니다. - 200."),
+	CREATED(HttpStatus.CREATED, "NOF-201", "리소스가 생성되었습니다. - 201"),
+	NO_CONTENT(HttpStatus.NO_CONTENT, "NOF-204", "요청이 성공했습니다. - 204"),
+	RESET_CONTENT(HttpStatus.RESET_CONTENT, "NOF-205", "리소스가 갱신되었습니다. - 205");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+
+}

--- a/src/main/java/com/notitime/noffice/global/response/ErrorCode.java
+++ b/src/main/java/com/notitime/noffice/global/response/ErrorCode.java
@@ -1,0 +1,11 @@
+package com.notitime.noffice.global.response;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+	HttpStatus getHttpStatus();
+
+	String getCode();
+
+	String getMessage();
+}

--- a/src/main/java/com/notitime/noffice/global/response/NofficeResponse.java
+++ b/src/main/java/com/notitime/noffice/global/response/NofficeResponse.java
@@ -1,0 +1,57 @@
+package com.notitime.noffice.global.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({"timestamp", "httpStatus", "code", "message", "data"})
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class NofficeResponse<T> {
+
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm:ss", timezone = "Asia/Seoul")
+	@JsonProperty("timestamp")
+	private LocalDateTime timestamp = LocalDateTime.now();
+
+	private final int httpStatus;
+
+	private final String code;
+
+	private final String message;
+
+	@JsonInclude(value = Include.NON_NULL)
+	private T data;
+
+	public static <T> NofficeResponse<T> success(SuccessCode success) {
+		return new NofficeResponse<>(success.getHttpStatus().value(), success.getCode(), success.getMessage());
+	}
+
+	public static <T> NofficeResponse<T> success(SuccessCode success, T data) {
+		return new NofficeResponse<>(success.getHttpStatus().value(), success.getCode(), success.getMessage(), data);
+	}
+
+	public static <T> NofficeResponse<T> fail(ErrorCode error) {
+		return new NofficeResponse<>(error.getHttpStatus().value(), error.getCode(), error.getMessage());
+	}
+
+	NofficeResponse(int httpStatus, String code, String message) {
+		this.httpStatus = httpStatus;
+		this.code = code;
+		this.message = message;
+	}
+
+	NofficeResponse(int httpStatus, String code, String message, T data) {
+		this.httpStatus = httpStatus;
+		this.code = code;
+		this.message = message;
+		this.data = data;
+	}
+}

--- a/src/main/java/com/notitime/noffice/global/response/SuccessCode.java
+++ b/src/main/java/com/notitime/noffice/global/response/SuccessCode.java
@@ -1,0 +1,14 @@
+package com.notitime.noffice.global.response;
+
+import org.springframework.http.HttpStatus;
+
+public interface SuccessCode {
+
+	HttpStatus getHttpStatus();
+	
+	String getCode();
+
+	String getMessage();
+}
+
+


### PR DESCRIPTION
## 🚀 Related Issue

close: #1 

## 📌 Tasks

- `Application` server 내 API 요청에 대한 응답 형식을 통일하였습니다.
- API에 대한 응답은 아래와 같은 형식 내 `HttpStatusCode` 상태코드가 부여됩니다.

## 📝 Details

- 실질적 business DTO는 `data` 필드에 담깁니다.
- Error, Exception 역시 같은 형식을 타고 전달됩니다. 

```json
{
    "timestamp": "2024.07.21 16:00:00",
    "httpStatus": 200, // httpStatus는 header에도 명시됩니다.
    "code": "NOF-200",
    "message": "요청이 성공했습니다. - 200.",
    "data": "test"
}
``` 
- list 혹은 `pageable`한 Response의 경우 역시 data 필드에 담깁니다.
```json
{
    "timestamp": "2024.07.21 16:24:17",
    "httpStatus": 204,
    "code": "NOF-204",
    "message": "요청이 성공했습니다. - 204",
    "data": [
        {
            "id": 1,
            "name": "test"
        },
        {
            "id": 2,
            "name": "test2"
        }
    ]
}
```

## 📚 Remarks

- HttpStatus는 필요할 것 같아 body에도 실었는데, header에도 충분할 시 제외하겠습니다 ~ `code` 필드와 유사한 역할을 수행합니다.