### PR TITLE
✨ [Feat] 기본 도메인 API Signiture

### DIFF
--- a/src/main/java/com/notitime/noffice/global/config/SwaggerConfig.java
+++ b/src/main/java/com/notitime/noffice/global/config/SwaggerConfig.java
@@ -4,25 +4,34 @@ package com.notitime.noffice.global.config;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
-
 	@Bean
-	public OpenAPI api() {
-		Server server = new Server().url("/");
+	public OpenAPI openAPI() {
+
+		Server localServer = new Server();
+		localServer.setDescription("local server");
+		localServer.setUrl("http://localhost:8080");
+
+		Server productionServer = new Server();
+		productionServer.setDescription("develop server");
+
+		productionServer.setUrl("https://api.noffice.store");
 
 		return new OpenAPI()
 				.info(getSwaggerInfo())
-				.addServersItem(server);
+				.servers(List.of(localServer, productionServer));
 	}
 
 	private Info getSwaggerInfo() {
 		return new Info()
 				.title("NOFFICE API Docs")
-				.description("TEST: NOFFICE API Docs")
+				.description("테스트 프로덕션용 NOFFICE API 명세서입니다.\n" +
+						"공통된 응답 형식은 Schemas-NofficeResponseString을 참고해주세요.")
 				.version("v1.0");
 	}
 }

--- a/src/main/java/com/notitime/noffice/global/config/SwaggerConfig.java
+++ b/src/main/java/com/notitime/noffice/global/config/SwaggerConfig.java
@@ -22,9 +22,13 @@ public class SwaggerConfig {
 
 		productionServer.setUrl("https://api.noffice.store");
 
+		Server testServer = new Server();
+		testServer.setDescription("develop server");
+
+		testServer.setUrl("https://97d4-61-72-170-128.ngrok-free.app");
 		return new OpenAPI()
 				.info(getSwaggerInfo())
-				.servers(List.of(localServer, productionServer));
+				.servers(List.of(localServer, productionServer, testServer));
 	}
 
 	private Info getSwaggerInfo() {

--- a/src/main/java/com/notitime/noffice/global/response/BusinessSuccessCode.java
+++ b/src/main/java/com/notitime/noffice/global/response/BusinessSuccessCode.java
@@ -8,9 +8,24 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum BusinessSuccessCode implements SuccessCode {
 
-	OK(HttpStatus.OK, "NOF-200", "요청이 성공했습니다. - 200."),
-	CREATED(HttpStatus.CREATED, "NOF-201", "리소스가 생성되었습니다. - 201"),
-	NO_CONTENT(HttpStatus.NO_CONTENT, "NOF-204", "요청이 성공했습니다. - 204"),
+	// OK (200 ~ 2099)
+	OK(HttpStatus.OK, "NOF-2000", "요청이 성공했습니다."),
+	POST_LOGIN_SUCCESS(HttpStatus.OK, "NOF-2000", "로그인에 성공하였습니다."),
+	POST_REISSUE_SUCCESS(HttpStatus.OK, "NOF-2000", "액세스 토큰 재발급에 성공하였습니다."),
+	GET_MEMBER_SUCCESS(HttpStatus.OK, "NOF-2001", "회원 정보 조회에 성공하였습니다."),
+	GET_JOINED_ORGANIZATIONS_SUCCESS(HttpStatus.OK, "NOF-2002", "회원의 가입된 조직 조회에 성공하였습니다."),
+	GET_ORGANIZATION_SUCCESS(HttpStatus.OK, "NOF-2003", "조직 정보 조회에 성공하였습니다."),
+	GET_CATEGORY_SUCCESS(HttpStatus.OK, "NOF-2004", "카테고리 조회에 성공하였습니다."),
+
+	// CREATED (2100 ~ 2199)
+	CREATED(HttpStatus.CREATED, "NOF-210", "리소스가 생성되었습니다. - 201"),
+	POST_ORGANIZATION_SUCCESS(HttpStatus.CREATED, "NOF-2100", "조직 생성에 성공하였습니다."),
+	POST_JOIN_ORGANIZATION_SUCCESS(HttpStatus.CREATED, "NOF-2101", "조직 가입에 성공하였습니다."),
+
+	// NO CONTENT (2400 ~ 2499)
+	NO_CONTENT(HttpStatus.NO_CONTENT, "NOF-2400", "요청이 성공했습니다. - 204"),
+
+	// RESET CONTENT (2500 ~ 2599)
 	RESET_CONTENT(HttpStatus.RESET_CONTENT, "NOF-205", "리소스가 갱신되었습니다. - 205");
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/notitime/noffice/health/HealthController.java
+++ b/src/main/java/com/notitime/noffice/health/HealthController.java
@@ -1,10 +1,15 @@
 package com.notitime.noffice.health;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "서버 헬스 체크", description = "노피스 서버 상태 확인 API")
 @RestController
 public class HealthController {
+
+	@Operation(summary = "서버 상태 확인", description = "정상 동작시 OK 반환합니다.")
 	@GetMapping("/health")
 	public String health() {
 		return "OK";

--- a/src/main/java/com/notitime/noffice/presentation/CategoryController.java
+++ b/src/main/java/com/notitime/noffice/presentation/CategoryController.java
@@ -1,0 +1,31 @@
+package com.notitime.noffice.presentation;
+
+import com.notitime.noffice.global.response.BusinessSuccessCode;
+import com.notitime.noffice.global.response.NofficeResponse;
+import com.notitime.noffice.response.CategoryResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "카테고리", description = "조직 내 카테고리 조회 API")
+@RestController
+@RequestMapping("/v1/category")
+@RequiredArgsConstructor
+public class CategoryController {
+
+	@Operation(summary = "전체 카테고리 조회")
+	@GetMapping
+	public NofficeResponse<CategoryResponses> getCategories() {
+		return NofficeResponse.success(BusinessSuccessCode.GET_CATEGORY_SUCCESS);
+	}
+
+	@Operation(summary = "특정 조직의 카테고리 조회")
+	@GetMapping("/organization/{organizationId}")
+	public NofficeResponse<CategoryResponses> getCategoriesByOrganization(@PathVariable Long organizationId) {
+		return NofficeResponse.success(BusinessSuccessCode.GET_CATEGORY_SUCCESS);
+	}
+}

--- a/src/main/java/com/notitime/noffice/presentation/MemberController.java
+++ b/src/main/java/com/notitime/noffice/presentation/MemberController.java
@@ -1,0 +1,51 @@
+package com.notitime.noffice.presentation;
+
+import com.notitime.noffice.global.response.BusinessSuccessCode;
+import com.notitime.noffice.global.response.NofficeResponse;
+import com.notitime.noffice.request.SocialAuthRequest;
+import com.notitime.noffice.response.MemberResponse;
+import com.notitime.noffice.response.OrganizationResponses;
+import com.notitime.noffice.response.SocialAuthResponse;
+import com.notitime.noffice.response.TokenResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "회원", description = "회원 로그인, 정보 조회 API")
+@RestController
+@RequestMapping("/v1/member")
+@RequiredArgsConstructor
+public class MemberController {
+
+	@Operation(summary = "회원 로그인", description = "인증 헤더에 토큰을, 본문에 소셜 로그인 정보를 넣어 노피스 서버 로그인을 시도합니다.")
+	@PostMapping("/login")
+	public NofficeResponse<SocialAuthResponse> login(@RequestHeader("Authorization") final String authorization,
+	                                                 @RequestBody final SocialAuthRequest socialLoginRequest) {
+		return NofficeResponse.success(BusinessSuccessCode.POST_LOGIN_SUCCESS);
+	}
+
+	@Operation(summary = "토큰 재발급", description = "리프레시 토큰을 이용해 새로운 액세스 토큰을 발급합니다.")
+	@PostMapping("/reissue")
+	public NofficeResponse<TokenResponse> reissue(@RequestHeader("Authorization") final String refreshToken) {
+		return NofficeResponse.success(BusinessSuccessCode.POST_REISSUE_SUCCESS);
+	}
+
+	@Operation(summary = "단일 회원 정보 조회")
+	@GetMapping("/{memberId}")
+	public NofficeResponse<MemberResponse> getMember(@PathVariable final Long memberId) {
+		return NofficeResponse.success(BusinessSuccessCode.GET_MEMBER_SUCCESS);
+	}
+
+	@Operation(summary = "멤버가 가입한 조직 목록 조회")
+	@GetMapping("/{memberId}/organizations")
+	public NofficeResponse<OrganizationResponses> getJoinedOrganizations(@PathVariable final Long memberId) {
+		return NofficeResponse.success(BusinessSuccessCode.GET_JOINED_ORGANIZATIONS_SUCCESS);
+	}
+}

--- a/src/main/java/com/notitime/noffice/presentation/OrganizationController.java
+++ b/src/main/java/com/notitime/noffice/presentation/OrganizationController.java
@@ -1,0 +1,52 @@
+package com.notitime.noffice.presentation;
+
+import com.notitime.noffice.global.response.BusinessSuccessCode;
+import com.notitime.noffice.global.response.NofficeResponse;
+import com.notitime.noffice.request.OrganizationCreateRequest;
+import com.notitime.noffice.request.OrganizationJoinRequest;
+import com.notitime.noffice.response.OrganizationJoinResponse;
+import com.notitime.noffice.response.OrganizationResponse;
+import com.notitime.noffice.response.OrganizationResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "조직", description = "조직 가입, 정보 조회 API")
+@RestController
+@RequestMapping("/v1/organization")
+@RequiredArgsConstructor
+public class OrganizationController {
+
+	@Operation(summary = "단일 조직 정보 조회")
+	@GetMapping("/{organizationId}")
+	public NofficeResponse<OrganizationResponse> getOrganization(@PathVariable Long organizationId) {
+		return NofficeResponse.success(BusinessSuccessCode.GET_ORGANIZATION_SUCCESS);
+	}
+
+	@Operation(summary = "조직 목록 조회")
+	@GetMapping("/list")
+	public NofficeResponse<OrganizationResponses> getOrganizationList() {
+		return NofficeResponse.success(BusinessSuccessCode.GET_ORGANIZATION_SUCCESS);
+	}
+
+	@Operation(summary = "조직 생성")
+	@PostMapping
+	public NofficeResponse<OrganizationResponse> createOrganization(
+			@RequestBody @Valid final OrganizationCreateRequest request) {
+		return NofficeResponse.success(BusinessSuccessCode.POST_ORGANIZATION_SUCCESS);
+	}
+
+	@Operation(summary = "멤버의 조직 가입")
+	@PostMapping("/{organizationId}/join")
+	public NofficeResponse<OrganizationJoinResponse> joinOrganization(@PathVariable Long organizationId,
+	                                                                  @RequestBody @Valid final OrganizationJoinRequest request) {
+		return NofficeResponse.success(BusinessSuccessCode.POST_JOIN_ORGANIZATION_SUCCESS);
+	}
+}

--- a/src/main/java/com/notitime/noffice/request/CategoryRequest.java
+++ b/src/main/java/com/notitime/noffice/request/CategoryRequest.java
@@ -1,0 +1,9 @@
+package com.notitime.noffice.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record CategoryRequest(
+		@Schema(description = "카테고리 아이디 리스트", example = "1,3,5")
+		List<Long> categoryIds) {
+}

--- a/src/main/java/com/notitime/noffice/request/OrganizationCreateRequest.java
+++ b/src/main/java/com/notitime/noffice/request/OrganizationCreateRequest.java
@@ -1,0 +1,21 @@
+package com.notitime.noffice.request;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
+
+public record OrganizationCreateRequest(
+		@NotNull(message = "그룹의 이름을 입력해주세요.")
+		String name,
+		@NotNull(message = "그룹의 카테고리를 선택해주세요.")
+		CategoryRequest categories,
+		@Nullable
+		String profile_image,
+		@DateTimeFormat(pattern = "yyyy-MM-dd")
+		@Nullable
+		LocalDate organizationEndAt,
+		@Nullable
+		String promotion_code
+) {
+}

--- a/src/main/java/com/notitime/noffice/request/OrganizationJoinRequest.java
+++ b/src/main/java/com/notitime/noffice/request/OrganizationJoinRequest.java
@@ -1,0 +1,9 @@
+package com.notitime.noffice.request;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+public record OrganizationJoinRequest(@Parameter(description = "멤버 ID", required = true)
+                                      Long memberId, Long organizationId) {
+
+
+}

--- a/src/main/java/com/notitime/noffice/request/SocialAuthRequest.java
+++ b/src/main/java/com/notitime/noffice/request/SocialAuthRequest.java
@@ -1,0 +1,12 @@
+package com.notitime.noffice.request;
+
+import com.notitime.noffice.domain.SocialAuthProvider;
+
+public record SocialAuthRequest(
+		SocialAuthProvider provider,
+		String code
+) {
+	public static SocialAuthRequest of(SocialAuthProvider provider, String code) {
+		return new SocialAuthRequest(provider, code);
+	}
+}

--- a/src/main/java/com/notitime/noffice/response/CategoryResponse.java
+++ b/src/main/java/com/notitime/noffice/response/CategoryResponse.java
@@ -1,0 +1,10 @@
+package com.notitime.noffice.response;
+
+import com.notitime.noffice.domain.Category;
+
+public record CategoryResponse(Long id, String name) {
+
+	public static CategoryResponse of(Category category) {
+		return new CategoryResponse(category.getId(), category.getName());
+	}
+}

--- a/src/main/java/com/notitime/noffice/response/CategoryResponses.java
+++ b/src/main/java/com/notitime/noffice/response/CategoryResponses.java
@@ -1,0 +1,16 @@
+package com.notitime.noffice.response;
+
+import com.notitime.noffice.domain.Category;
+import java.util.List;
+
+public record CategoryResponses(List<CategoryResponse> categories) {
+
+	public static CategoryResponses from(List<Category> categories) {
+		List<CategoryResponse> responses = categories.stream()
+				.map(CategoryResponse::of)
+				.toList();
+
+		return new CategoryResponses(responses);
+	}
+}
+

--- a/src/main/java/com/notitime/noffice/response/MemberResponse.java
+++ b/src/main/java/com/notitime/noffice/response/MemberResponse.java
@@ -1,0 +1,11 @@
+package com.notitime.noffice.response;
+
+import com.notitime.noffice.domain.Member;
+
+public record MemberResponse(Long id, String name, String alias, String profileImage,
+                             OrganizationResponses organizations) {
+	public static MemberResponse of(Member member) {
+		return new MemberResponse(member.getId(), member.getName(), member.getAlias(),
+				member.getProfileImage(), OrganizationResponses.from(member.getOrganizations()));
+	}
+}

--- a/src/main/java/com/notitime/noffice/response/MemberResponses.java
+++ b/src/main/java/com/notitime/noffice/response/MemberResponses.java
@@ -1,0 +1,4 @@
+package com.notitime.noffice.response;
+
+public record MemberResponses() {
+}

--- a/src/main/java/com/notitime/noffice/response/OrganizationInfoResponse.java
+++ b/src/main/java/com/notitime/noffice/response/OrganizationInfoResponse.java
@@ -1,0 +1,15 @@
+package com.notitime.noffice.response;
+
+import com.notitime.noffice.domain.Organization;
+import java.time.LocalDateTime;
+
+public record OrganizationInfoResponse(Long id, String name, LocalDateTime endAt, String profileImage) {
+
+	public static OrganizationInfoResponse of(Organization organization) {
+		return new OrganizationInfoResponse(
+				organization.getId(),
+				organization.getName(),
+				organization.getEndAt(),
+				organization.getProfileImage());
+	}
+}

--- a/src/main/java/com/notitime/noffice/response/OrganizationJoinResponse.java
+++ b/src/main/java/com/notitime/noffice/response/OrganizationJoinResponse.java
@@ -1,0 +1,4 @@
+package com.notitime.noffice.response;
+
+public record OrganizationJoinResponse(Long id, String name, String link) {
+}

--- a/src/main/java/com/notitime/noffice/response/OrganizationResponse.java
+++ b/src/main/java/com/notitime/noffice/response/OrganizationResponse.java
@@ -1,0 +1,13 @@
+package com.notitime.noffice.response;
+
+import com.notitime.noffice.domain.Organization;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record OrganizationResponse(
+		@Schema(description = "조직 ID") Long id,
+		@Schema(description = "조직 이름") String name) {
+
+	public static OrganizationResponse of(Organization organization) {
+		return new OrganizationResponse(organization.getId(), organization.getName());
+	}
+}

--- a/src/main/java/com/notitime/noffice/response/OrganizationResponses.java
+++ b/src/main/java/com/notitime/noffice/response/OrganizationResponses.java
@@ -1,0 +1,14 @@
+package com.notitime.noffice.response;
+
+import com.notitime.noffice.domain.OrganizationMember;
+import java.util.List;
+
+public record OrganizationResponses(List<OrganizationResponse> organizations) {
+	public static OrganizationResponses from(List<OrganizationMember> organizations) {
+		List<OrganizationResponse> responses = organizations.stream()
+				.map(organization -> OrganizationResponse.of(organization.getOrganization()))
+				.toList();
+
+		return new OrganizationResponses(responses);
+	}
+}

--- a/src/main/java/com/notitime/noffice/response/SocialAuthResponse.java
+++ b/src/main/java/com/notitime/noffice/response/SocialAuthResponse.java
@@ -1,0 +1,19 @@
+package com.notitime.noffice.response;
+
+import com.notitime.noffice.domain.SocialAuthProvider;
+
+public record SocialAuthResponse(
+		Long memberId,
+		String memberName,
+		SocialAuthProvider provider,
+		TokenResponse token
+) {
+	public static SocialAuthResponse of(Long memberId, String memberName, SocialAuthProvider provider,
+	                                    TokenResponse token) {
+		return new SocialAuthResponse(
+				memberId,
+				memberName,
+				provider,
+				TokenResponse.of(token.accessToken(), token.refreshToken()));
+	}
+}

--- a/src/main/java/com/notitime/noffice/response/TokenResponse.java
+++ b/src/main/java/com/notitime/noffice/response/TokenResponse.java
@@ -1,0 +1,10 @@
+package com.notitime.noffice.response;
+
+public record TokenResponse(
+		String accessToken,
+		String refreshToken
+) {
+	public static TokenResponse of(String accessToken, String refreshToken) {
+		return new TokenResponse("Bearer " + accessToken, "Bearer " + refreshToken);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,8 @@ spring:
       hibernate:
         format_sql: true
     show-sql: true
+
+springdoc:
+  swagger-ui:
+    tags-sorter: alpha
+    operations-sorter: alpha


### PR DESCRIPTION
## 🚀 Related Issue

close: #15 

## 📌 Tasks

- 기본 도메인(`사용자`, `조직`, `카테고리`) 기능 수행을 위한 `Dev-test API` Signiture를 정의합니다.

## 📝 Details
- API 규격은 회의를 통해 정의된 1차 배포 계획안에 의해 정의되었습니다.
- 각 요청이 성공할 시 `NOF-200 +@` 형태의 비즈니스 응답 코드가 부여됩니다. 

## 📚 Remarks
- 일부 요청 필드에 `Nullable` 스펙이 정의되지 않았는데, 비즈니스 로직 구현 시 수정될 여지가 있으므로 현재는 모두 Nullable 전송이 가능한 상태입니다.