### PR TITLE
✨ [Feat] Spring OpenFeign Configuration 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.5'
 }
 
+ext {
+	springCloudVersion = "2023.0.3"
+}
+
 group = 'com.notitime'
 version = '0.0.1-SNAPSHOT'
 
@@ -27,6 +31,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -44,4 +49,10 @@ tasks.named('test') {
 jar{
 	// disable default bootJar task
 	enabled = false
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion"
+	}
 }

--- a/src/main/java/com/notitime/noffice/external/config/FeignConfig.java
+++ b/src/main/java/com/notitime/noffice/external/config/FeignConfig.java
@@ -1,0 +1,10 @@
+package com.notitime.noffice.external.config;
+
+import com.notitime.noffice.NofficeApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackageClasses = NofficeApplication.class)
+public class FeignConfig {
+}


### PR DESCRIPTION
## 🚀 Related Issue

close: #17 

## 📌 Tasks

- OpenFeign 의존성을 추가하였습니다.
- 외부 서버 통신 client 구현부를 `external` 패키지로 분리하였습니다.

## 📝 Details

`version`: openfeign 4.1.3
```gradle
implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
```

## 📚 Remarks

- 
- 