### PR TITLE
🔥 [Fix] oauth AppleAuthStrategy 환경변수 주입 에러

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -42,9 +42,13 @@ jobs:
           echo "Secrets : ${{secrets.APPLE_TEAM_ID}}"
           echo "Secrets : ${{secrets.APPLE_PRIVATE_KEY}}"
 
-
       - name: Build with Gradle Wrapper
         run: ./gradlew build
+        env:
+          APPLE_CLIENT_ID: ${{secrets.APPLE_CLIENT_ID}}
+          APPLE_KEY_ID: ${{secrets.APPLE_KEY_ID}}
+          APPLE_TEAM_ID: ${{secrets.APPLE_TEAM_ID}}
+          APPLE_PRIVATE_KEY: ${{secrets.APPLE_PRIVATE_KEY}}
 
       - name: Get current time
         uses: 1466587594/get-current-time@v2

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -30,6 +30,19 @@ jobs:
         run: chmod +x ./gradlew
         shell: bash
 
+      - name: Access to Secrets
+        env:
+          APPLE_CLIENT_ID: ${{secrets.APPLE_CLIENT_ID}}
+          APPLE_KEY_ID: ${{secrets.APPLE_KEY_ID}}
+          APPLE_TEAM_ID: ${{secrets.APPLE_TEAM_ID}}
+          APPLE_PRIVATE_KEY: ${{secrets.APPLE_PRIVATE_KEY}}
+        run: |
+          echo "Secrets : ${{secrets.APPLE_CLIENT_ID}}"
+          echo "Secrets : ${{secrets.APPLE_KEY_ID}}"
+          echo "Secrets : ${{secrets.APPLE_TEAM_ID}}"
+          echo "Secrets : ${{secrets.APPLE_PRIVATE_KEY}}"
+
+
       - name: Build with Gradle Wrapper
         run: ./gradlew build
 

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -13,6 +13,12 @@ jobs:
     permissions:
       contents: read
 
+    env:
+      APPLE_CLIENT_ID: ${{secrets.APPLE_CLIENT_ID}}
+      APPLE_KEY_ID: ${{secrets.APPLE_KEY_ID}}
+      APPLE_TEAM_ID: ${{secrets.APPLE_TEAM_ID}}
+      APPLE_PRIVATE_KEY: ${{secrets.APPLE_PRIVATE_KEY}}
+
     steps:
       - name: checkout to develop branch
         uses: actions/checkout@v4
@@ -30,12 +36,7 @@ jobs:
         run: chmod +x ./gradlew
         shell: bash
 
-      - name: Access to Secrets
-        env:
-          APPLE_CLIENT_ID: ${{secrets.APPLE_CLIENT_ID}}
-          APPLE_KEY_ID: ${{secrets.APPLE_KEY_ID}}
-          APPLE_TEAM_ID: ${{secrets.APPLE_TEAM_ID}}
-          APPLE_PRIVATE_KEY: ${{secrets.APPLE_PRIVATE_KEY}}
+      - name: Access to Github Secrets
         run: |
           echo "Secrets : ${{secrets.APPLE_CLIENT_ID}}"
           echo "Secrets : ${{secrets.APPLE_KEY_ID}}"
@@ -44,11 +45,6 @@ jobs:
 
       - name: Build with Gradle Wrapper
         run: ./gradlew build
-        env:
-          APPLE_CLIENT_ID: ${{secrets.APPLE_CLIENT_ID}}
-          APPLE_KEY_ID: ${{secrets.APPLE_KEY_ID}}
-          APPLE_TEAM_ID: ${{secrets.APPLE_TEAM_ID}}
-          APPLE_PRIVATE_KEY: ${{secrets.APPLE_PRIVATE_KEY}}
 
       - name: Get current time
         uses: 1466587594/get-current-time@v2

--- a/src/main/java/com/notitime/noffice/api/auth/business/AuthService.java
+++ b/src/main/java/com/notitime/noffice/api/auth/business/AuthService.java
@@ -26,7 +26,6 @@ public class AuthService {
 	private final MemberRepository memberRepository;
 	private final RefreshTokenRepository refreshTokenRepository;
 
-
 	public SocialAuthResponse login(final SocialAuthRequest request) {
 		if (socialAuthContext.support(request.provider())) {
 			return socialAuthContext.doLogin(request);

--- a/src/main/java/com/notitime/noffice/api/auth/business/strategy/AppleAuthStrategy.java
+++ b/src/main/java/com/notitime/noffice/api/auth/business/strategy/AppleAuthStrategy.java
@@ -5,7 +5,10 @@ import com.notitime.noffice.domain.SocialAuthProvider;
 import com.notitime.noffice.domain.member.model.Member;
 import com.notitime.noffice.domain.member.persistence.MemberRepository;
 import com.notitime.noffice.external.openfeign.apple.AppleFeignClient;
+import com.notitime.noffice.external.openfeign.apple.AppleIdentityTokenParser;
 import com.notitime.noffice.external.openfeign.apple.AppleOAuthProvider;
+import com.notitime.noffice.external.openfeign.apple.ApplePublicKeyGenerator;
+import com.notitime.noffice.external.openfeign.apple.dto.ApplePublicKeys;
 import com.notitime.noffice.external.openfeign.apple.dto.AppleTokenResponse;
 import com.notitime.noffice.external.openfeign.dto.AuthorizedMemberInfo;
 import com.notitime.noffice.request.SocialAuthRequest;
@@ -13,16 +16,18 @@ import com.notitime.noffice.response.SocialAuthResponse;
 import com.notitime.noffice.response.TokenResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
-@Service
+@Component
 @RequiredArgsConstructor
 public class AppleAuthStrategy implements SocialAuthStrategy {
 
 	private final AppleFeignClient appleFeignClient;
 	private final AppleOAuthProvider appleOAuthProvider;
-	private final MemberRepository memberRepository;
 	private final JwtProvider jwtProvider;
+	private final AppleIdentityTokenParser appleIdentityTokenParser;
+	private final ApplePublicKeyGenerator applePublicKeyGenerator;
+	private final MemberRepository memberRepository;
 
 	@Value("${oauth.apple.client-id}")
 	private String clientId;
@@ -43,6 +48,7 @@ public class AppleAuthStrategy implements SocialAuthStrategy {
 				clientId,
 				clientSecret,
 				grantType);
+		ApplePublicKeys applePublicKeys = appleFeignClient.getApplePublicKey();
 		AuthorizedMemberInfo memberResponse = appleOAuthProvider.getAppleUserInfo(appleTokenResponse.idToken(),
 				request.provider().name(), applePublicKeys);
 		Member member = memberRepository.findBySerialId(memberResponse.serialId())

--- a/src/main/java/com/notitime/noffice/api/auth/business/strategy/AppleAuthStrategy.java
+++ b/src/main/java/com/notitime/noffice/api/auth/business/strategy/AppleAuthStrategy.java
@@ -44,7 +44,7 @@ public class AppleAuthStrategy implements SocialAuthStrategy {
 				clientSecret,
 				grantType);
 		AuthorizedMemberInfo memberResponse = appleOAuthProvider.getAppleUserInfo(appleTokenResponse.idToken(),
-				request.provider().name());
+				request.provider().name(), applePublicKeys);
 		Member member = memberRepository.findBySerialId(memberResponse.serialId())
 				.orElseGet(() -> Member.createAuthorizedMember(
 						memberResponse.serialId(),

--- a/src/main/java/com/notitime/noffice/api/auth/business/strategy/AppleAuthStrategy.java
+++ b/src/main/java/com/notitime/noffice/api/auth/business/strategy/AppleAuthStrategy.java
@@ -32,8 +32,8 @@ public class AppleAuthStrategy implements SocialAuthStrategy {
 	private String grantType;
 
 	@Override
-	public boolean support(String provider) {
-		return SocialAuthProvider.APPLE.toString().equals(provider);
+	public boolean support(SocialAuthProvider provider) {
+		return provider.equals(SocialAuthProvider.APPLE);
 	}
 
 	@Override

--- a/src/main/java/com/notitime/noffice/api/auth/business/strategy/SocialAuthContext.java
+++ b/src/main/java/com/notitime/noffice/api/auth/business/strategy/SocialAuthContext.java
@@ -25,7 +25,7 @@ public class SocialAuthContext {
 
 	public boolean support(SocialAuthProvider provider) {
 		for (SocialAuthStrategy strategy : socialAuthStrategies) {
-			if (strategy.support(provider.toString())) {
+			if (strategy.support(provider)) {
 				return true;
 			}
 		}
@@ -34,7 +34,7 @@ public class SocialAuthContext {
 
 	public SocialAuthResponse doLogin(final SocialAuthRequest request) {
 		for (SocialAuthStrategy strategy : socialAuthStrategies) {
-			if (strategy.support(request.provider().toString())) {
+			if (strategy.support(request.provider())) {
 				return strategy.login(request);
 			}
 		}

--- a/src/main/java/com/notitime/noffice/api/auth/business/strategy/SocialAuthStrategy.java
+++ b/src/main/java/com/notitime/noffice/api/auth/business/strategy/SocialAuthStrategy.java
@@ -1,5 +1,6 @@
 package com.notitime.noffice.api.auth.business.strategy;
 
+import com.notitime.noffice.domain.SocialAuthProvider;
 import com.notitime.noffice.request.SocialAuthRequest;
 import com.notitime.noffice.response.SocialAuthResponse;
 
@@ -7,5 +8,5 @@ public interface SocialAuthStrategy {
 
 	SocialAuthResponse login(final SocialAuthRequest request);
 
-	boolean support(String provider);
+	boolean support(SocialAuthProvider provider);
 }

--- a/src/main/java/com/notitime/noffice/external/openfeign/apple/AppleIdentityTokenParser.java
+++ b/src/main/java/com/notitime/noffice/external/openfeign/apple/AppleIdentityTokenParser.java
@@ -1,6 +1,7 @@
 package com.notitime.noffice.external.openfeign.apple;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.notitime.noffice.global.exception.UnauthorizedException;
 import com.notitime.noffice.global.response.BusinessErrorCode;
@@ -23,7 +24,7 @@ public class AppleIdentityTokenParser {
 		try {
 			String encodedHeader = identityToken.split("\\.")[0];
 			String decodedHeader = new String(Base64.getUrlDecoder().decode(encodedHeader));
-			return OBJECT_MAPPER.readValue(decodedHeader, Map.class);
+			return OBJECT_MAPPER.readValue(decodedHeader, new TypeReference<Map<String, String>>() {});
 		} catch (JsonProcessingException | ArrayIndexOutOfBoundsException e) {
 			throw new UnauthorizedException(BusinessErrorCode.INVALID_APPLE_IDENTITY_TOKEN);
 		}

--- a/src/main/java/com/notitime/noffice/external/openfeign/apple/AppleOAuthProvider.java
+++ b/src/main/java/com/notitime/noffice/external/openfeign/apple/AppleOAuthProvider.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class AppleOAuthProvider {
 
-	private final AppleFeignClient appleFeignClient;
 	private final AppleIdentityTokenParser appleIdentityTokenParser;
 	private final ApplePublicKeyGenerator applePublicKeyGenerator;
 

--- a/src/main/java/com/notitime/noffice/external/openfeign/apple/AppleOAuthProvider.java
+++ b/src/main/java/com/notitime/noffice/external/openfeign/apple/AppleOAuthProvider.java
@@ -1,10 +1,7 @@
 package com.notitime.noffice.external.openfeign.apple;
 
 import com.notitime.noffice.external.openfeign.apple.dto.ApplePublicKeys;
-import com.notitime.noffice.external.openfeign.apple.dto.AppleTokenResponse;
 import com.notitime.noffice.external.openfeign.dto.AuthorizedMemberInfo;
-import com.notitime.noffice.global.exception.BadRequestException;
-import com.notitime.noffice.global.response.BusinessErrorCode;
 import io.jsonwebtoken.Claims;
 import java.security.PublicKey;
 import java.util.Map;
@@ -25,31 +22,14 @@ public class AppleOAuthProvider {
 	@Value("${oauth.apple.client-id}")
 	private String clientId;
 
-	public AuthorizedMemberInfo getAppleUserInfo(final String identityToken, final String name) {
+	public AuthorizedMemberInfo getAppleUserInfo(final String identityToken, final String name,
+	                                             ApplePublicKeys applePublicKeys) {
 		Map<String, String> headers = appleIdentityTokenParser.parseHeaders(identityToken);
-		ApplePublicKeys applePublicKeys = appleFeignClient.getApplePublicKey();
 		PublicKey applePublicKey = applePublicKeyGenerator.generatePublicKey(headers, applePublicKeys);
 		Claims claims = appleIdentityTokenParser.parsePublicKeyAndGetClaims(identityToken, applePublicKey);
 		return AuthorizedMemberInfo.of(
 				claims.get("sub").toString(),
 				name,
 				claims.get("email").toString());
-	}
-
-	public String getAppleRefreshToken(final String code, final String clientSecret) {
-		try {
-			AppleTokenResponse appleTokenResponse = appleFeignClient.getAppleTokens(code, clientId, clientSecret,
-					"authorization_code");
-			log.info("Apple token response: {}", appleTokenResponse);
-			return appleTokenResponse.refreshToken();
-		} catch (Exception e) {
-			log.error("Failed to get apple refresh token.");
-			throw new BadRequestException(BusinessErrorCode.FAILED_TO_LOAD_PRIVATE_KEY);
-		}
-	}
-
-	public void requestRevoke(final String refreshToken, final String clientSecret) {
-		appleFeignClient.revoke(refreshToken, clientId, clientSecret, "refresh_token");
-		log.error("Failed to revoke apple refresh token.");
 	}
 }


### PR DESCRIPTION
## 🚀 Related Issue

close: #24 

## 📌 Tasks

- 서비스 로그아웃 및 탈퇴는 고려되지 않은 기능이므로 관련 메소드 제거
- 상위 모듈 AppleAuthStrategy에서의 중복 의존성 발생 제거
 - 주요 해결 요인은 아니나, 환경 변수로 주입되는 객체는 `LoginStrategy`에서 모두 주입하는 방식으로 관리하기 편하게 바꿈

## 📝 Details

- 요청 시 첨부되는 공개키를 인자로 주입하고 사용자 식별 정보만 파싱하는 책임을 갖도록 변경


## 📚 Remarks

- dev, prod infra에서 환경 변수 주입을 위한 profile 분리 작업 필요
- 