### PR TITLE
✨ [Feat] 공지 상태, 열람자 관련 테이블 스펙 수정

### DIFF
--- a/docs/NOFFICE-erd.md
+++ b/docs/NOFFICE-erd.md
@@ -55,7 +55,7 @@ erDiagram
         bigint id PK
         bigint announcement_id FK
         bigint member_id FK
-        boolean read
+        boolean is_read
         timestamp read_at
     }
 

--- a/docs/NOFFICE-erd.md
+++ b/docs/NOFFICE-erd.md
@@ -1,10 +1,13 @@
 # Noffice-mermaid ERD
 
+- [NOFFICE-ERD (ver 0.1.2)](https://www.mermaidchart.com/raw/8ac96ad3-73fd-476f-9e52-d32c2b602360?theme=light&version=v0.1&format=svg)
+
 ```mermaid
 ---
-title : NOFFICE-ERD (ver 1.0.1)
+title : NOFFICE-ERD (ver 1.0.2)
 ---
 erDiagram
+    MEMBER ||--|{ ORGANIZATION_MEMBER: belongs
     MEMBER {
         bigint id PK
         varchar name
@@ -15,60 +18,15 @@ erDiagram
         SocialAuthProvider social_auth_provider
     }
 
+    ORGANIZATION ||--|{ ORGANIZATION_MEMBER: belongs
+    ORGANIZATION ||--o{ ANNOUNCEMENT: "has"
     ORGANIZATION {
         bigint id PK
         varchar name
         timestamp end_at
-        varchar profile_image
+        text profile_image
     }
 
-    ORGANIZATION ||--|{ ORGANIZATION_CATEGORY: has
-    CATEGORY ||--|{ ORGANIZATION_CATEGORY: categorized
-    ORGANIZATION_CATEGORY {
-        bigint id PK
-        bigint organization_id FK
-        bigint category_id FK
-    }
-
-    CATEGORY {
-        bigint id PK
-        varchar name
-    }
-    ORGANIZATION_PROMOTION {
-        bigint id PK
-        bigint organization_id FK
-        bigint promotion_id FK
-        timestamp start_date
-        timestamp end_date
-    }
-
-    MEMBER ||--|{ ORGANIZATION_MEMBER: belongs
-    ORGANIZATION ||--|{ ORGANIZATION_MEMBER: belongs
-    ORGANIZATION_MEMBER {
-        bigint id PK
-        bigint organization_id FK
-        bigint member_id FK
-        OragnizationRole role
-    }
-
-    FCM_NOTIFICATION_TOKEN }o--|| MEMBER: "has"
-    FCM_NOTIFICATION_TOKEN {
-        bigint id PK
-        bigint member_id FK
-        varchar device_id
-        varchar fcm_token
-    }
-
-    MEMBER ||--|| REFRESH_TOKEN: authenticate
-    REFRESH_TOKEN {
-        varchar id PK
-        bigint member_id FK
-        varchar refresh_token
-        SocialAuthProvider auth_provider
-        timestamp expired_date_time
-    }
-
-    ORGANIZATION ||--o{ ANNOUNCEMENT: "has"
     ANNOUNCEMENT {
         bigint id PK
         bigint creator_id FK
@@ -78,23 +36,7 @@ erDiagram
         varchar cover_image
         varchar place_link_title
         varchar place_link_url
-        timestamp start_at
         timestamp end_at
-        timestamp notice_at
-    }
-    ORGANIZATION ||--o{ ORGANIZATION_PROMOTION: "promote event"
-    PROMOTION ||--o{ ORGANIZATION_PROMOTION: ""
-    PROMOTION {
-        bigint id PK
-        varchar code
-        boolean used
-    }
-
-    ANNOUNCEMENT ||--o{ TASK: has
-    TASK {
-        bigint id PK
-        bigint announce_id FK
-        varchar content
     }
 
     MEMBER ||--o{ TASK_STATUS: records
@@ -107,6 +49,23 @@ erDiagram
         timestamp checked_at
     }
 
+    ANNOUNCEMENT ||--o{ ANNOUNCEMENT_READ_STATUS: "records read status"
+    MEMBER ||--o{ ANNOUNCEMENT_READ_STATUS: "records read status"
+    ANNOUNCEMENT_READ_STATUS {
+        bigint id PK
+        bigint announcement_id FK
+        bigint member_id FK
+        boolean read
+        timestamp read_at
+    }
+
+    ANNOUNCEMENT ||--o{ TASK: has
+    TASK {
+        bigint id PK
+        bigint announce_id FK
+        varchar content
+    }
+
     ANNOUNCEMENT ||--|{ ANNOUNCEMENT_IMAGE: "has"
     ANNOUNCEMENT_IMAGE {
         bigint id PK
@@ -115,9 +74,50 @@ erDiagram
         boolean is_promotion
     }
 
+    ORGANIZATION_MEMBER {
+        bigint id PK
+        bigint organization_id FK
+        bigint member_id FK
+        OragnizationRole role
+    }
+    ORGANIZATION ||--|{ ORGANIZATION_CATEGORY: has
+    ORGANIZATION_CATEGORY {
+        bigint id PK
+        bigint organization_id FK
+        bigint category_id FK
+    }
+    CATEGORY ||--|{ ORGANIZATION_CATEGORY: categorized
+    CATEGORY {
+        bigint id PK
+        varchar name
+    }
+    ORGANIZATION ||--o{ ORGANIZATION_PROMOTION: "promote event"
+    PROMOTION ||--o{ ORGANIZATION_PROMOTION: ""
+    PROMOTION {
+        bigint id PK
+        varchar code
+        boolean is_used
+    }
+
+    PROMOTION ||--o{ PROMOTION_IMAGE: "has"
     PROMOTION_IMAGE {
         bigint id PK
+        bigint promotion_id FK
         text image_url
+    }
+
+    ORGANIZATION_PROMOTION {
+        bigint id PK
+        bigint organization_id FK
+        bigint promotion_id FK
+        timestamp end_at
+    }
+
+    ANNOUNCEMENT ||--o{ NOTIFICATION: "record send time"
+    NOTIFICATION {
+        bigint id PK
+        bigint announcement_id FK
+        timestamp send_at
     }
 
     BASETIMEENTITY {

--- a/src/main/java/com/notitime/noffice/domain/AnnounceReadStatus.java
+++ b/src/main/java/com/notitime/noffice/domain/AnnounceReadStatus.java
@@ -4,6 +4,7 @@ import com.notitime.noffice.domain.member.model.Member;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -15,20 +16,20 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class TaskStatus extends BaseTimeEntity {
+public class AnnounceReadStatus {
+
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	private Boolean isChecked;
-
-	private LocalDateTime checkedAt;
-
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "task_id")
-	private Task task;
+	private Boolean isRead;
+	private LocalDateTime readAt;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id")
+	@JoinColumn(name = "member_id", nullable = false)
 	private Member member;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "announcement_id", nullable = false)
+	private Announcement announcement;
 }

--- a/src/main/java/com/notitime/noffice/domain/Announcement.java
+++ b/src/main/java/com/notitime/noffice/domain/Announcement.java
@@ -22,6 +22,8 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Announcement extends BaseTimeEntity {
 
+	public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
 	@Id
 	private Long id;
 

--- a/src/main/java/com/notitime/noffice/domain/Announcement.java
+++ b/src/main/java/com/notitime/noffice/domain/Announcement.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;

--- a/src/main/java/com/notitime/noffice/domain/Announcement.java
+++ b/src/main/java/com/notitime/noffice/domain/Announcement.java
@@ -2,13 +2,17 @@ package com.notitime.noffice.domain;
 
 import com.notitime.noffice.domain.member.model.Member;
 import com.notitime.noffice.domain.organization.model.Organization;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,16 +33,21 @@ public class Announcement extends BaseTimeEntity {
 	@Column(columnDefinition = "TEXT")
 	private String profileImageUrl;
 
+	@Column(nullable = false)
+	private boolean isFaceToFace;
+
 	private String placeLinkName;
 
 	@Column(columnDefinition = "TEXT")
 	private String placeLinkUrl;
 
-	private LocalDateTime startAt;
-
 	private LocalDateTime endAt;
 
-	private LocalDateTime noticeAt;
+	@OneToMany(mappedBy = "announcement", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Task> tasks = new ArrayList<>();
+
+	@OneToMany(mappedBy = "announcement", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Notification> notifications = new ArrayList<>();
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "creator_id")

--- a/src/main/java/com/notitime/noffice/domain/AnnouncementImage.java
+++ b/src/main/java/com/notitime/noffice/domain/AnnouncementImage.java
@@ -13,7 +13,6 @@ public class AnnouncementImage {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 	private String imageUrl;
-	private String imageType;
 	@ManyToOne
 	@JoinColumn(name = "announcement_id")
 	private Announcement announcement;

--- a/src/main/java/com/notitime/noffice/domain/BaseTimeEntity.java
+++ b/src/main/java/com/notitime/noffice/domain/BaseTimeEntity.java
@@ -4,18 +4,20 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@Getter
 public abstract class BaseTimeEntity {
 
 	@CreatedDate
 	@Column(updatable = false)
-	private LocalDateTime createdDate;
+	private LocalDateTime createdAt;
 
 	@LastModifiedDate
-	private LocalDateTime lastModifiedDate;
+	private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/notitime/noffice/domain/Notification.java
+++ b/src/main/java/com/notitime/noffice/domain/Notification.java
@@ -1,0 +1,29 @@
+package com.notitime.noffice.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Notification {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "announcement_id", nullable = false)
+	private Announcement announcement;
+
+	private LocalDateTime sendAt;
+}

--- a/src/main/java/com/notitime/noffice/domain/OrganizationPromotion.java
+++ b/src/main/java/com/notitime/noffice/domain/OrganizationPromotion.java
@@ -27,6 +27,5 @@ public class OrganizationPromotion {
 	@JoinColumn(name = "promotion_id", nullable = false)
 	private Promotion promotion;
 
-	private LocalDateTime startDate;
-	private LocalDateTime endDate;
+	private LocalDateTime endAt;
 }

--- a/src/main/java/com/notitime/noffice/domain/PromotionImage.java
+++ b/src/main/java/com/notitime/noffice/domain/PromotionImage.java
@@ -2,9 +2,12 @@ package com.notitime.noffice.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 
 @Entity
 public class PromotionImage {
@@ -12,6 +15,10 @@ public class PromotionImage {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "promotion_id", nullable = false)
+	private Promotion promotion;
+	
 	@Column(columnDefinition = "TEXT")
 	private String imageUrl;
 }

--- a/src/main/java/com/notitime/noffice/domain/Task.java
+++ b/src/main/java/com/notitime/noffice/domain/Task.java
@@ -1,9 +1,13 @@
 package com.notitime.noffice.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,9 +21,10 @@ public class Task {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	private Long announceId;
-
-	private Long organizationId;
-
+	@Column(nullable = false)
 	private String content;
+	
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "announcement_id", nullable = false)
+	private Announcement announcement;
 }

--- a/src/main/java/com/notitime/noffice/domain/TaskStatus.java
+++ b/src/main/java/com/notitime/noffice/domain/TaskStatus.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,12 +15,14 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class TaskStatus {
+public class TaskStatus extends BaseTimeEntity {
 	@Id
 	@GeneratedValue
 	private Long id;
 
 	private Boolean checked;
+
+	private LocalDateTime checkedAt;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "task_id")

--- a/src/main/java/com/notitime/noffice/domain/organization/model/Organization.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/model/Organization.java
@@ -1,6 +1,7 @@
 package com.notitime.noffice.domain.organization.model;
 
 import com.notitime.noffice.domain.BaseTimeEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -22,5 +23,6 @@ public class Organization extends BaseTimeEntity {
 
 	private LocalDateTime endAt;
 
+	@Column(columnDefinition = "TEXT")
 	private String profileImage;
 }

--- a/src/main/java/com/notitime/noffice/global/health/HealthApi.java
+++ b/src/main/java/com/notitime/noffice/global/health/HealthApi.java
@@ -1,4 +1,4 @@
-package com.notitime.noffice.health;
+package com.notitime.noffice.global.health;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "서버 헬스 체크", description = "노피스 서버 상태 확인 API")
 @RestController
-public class HealthController {
+public class HealthApi {
 
 	@Operation(summary = "서버 상태 확인", description = "정상 동작시 OK 반환합니다.")
 	@GetMapping("/health")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,9 @@ spring:
         ddl-auto: create
         format_sql: true
 
+  jackson:
+    property-naming-strategy: LOWER_CAMEL_CASE
+
 springdoc:
   swagger-ui:
     path: /swagger-ui.html


### PR DESCRIPTION
## 🚀 Related Issue

close: #33 #31 

## 📌 Tasks

- 공지 열람자/미열람자를 관리하는 Announce_read_status(Announce-Member related table) 엔티티 승격
- 프로모션 - 커버 이미지 연관관계 부여 (1:N)
- 모든 엔티티 url 저장 필드 column 스키마 변경 ( VARCHAR(255) -> TEXT)


## 📝 Details

- dto LowerCamelCase strategy 주입 #31 
```yaml
  jackson:
    property-naming-strategy: LOWER_CAMEL_CASE
```

## 📚 Remarks

- url 부분은 실제 들어오는 값 보고 varchar length 정해서 가변 데이터 쓰지 않아도 무방할 것으로 예상