### PR TITLE
🔒 Feat : Web Request Whitelist Security 검증 파이프라인 구성

### DIFF
--- a/src/main/java/com/notitime/noffice/auth/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/notitime/noffice/auth/JwtAuthenticationEntryPoint.java
@@ -1,6 +1,7 @@
 package com.notitime.noffice.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.notitime.noffice.global.config.SecurityWhiteListPaths;
 import com.notitime.noffice.global.response.BusinessErrorCode;
 import com.notitime.noffice.global.response.NofficeResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,10 +18,11 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
-	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response,
 	                     AuthenticationException authException) throws IOException {
-		handleException(response);
+		if (!SecurityWhiteListPaths.isWhitelisted(request)) {
+			handleException(response);
+		}
 	}
 
 	private void handleException(HttpServletResponse response) throws IOException {

--- a/src/main/java/com/notitime/noffice/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/notitime/noffice/auth/filter/JwtAuthenticationFilter.java
@@ -5,6 +5,7 @@ import static com.notitime.noffice.auth.UserAuthentication.createUserAuthenticat
 import com.notitime.noffice.auth.UserAuthentication;
 import com.notitime.noffice.auth.jwt.JwtProvider;
 import com.notitime.noffice.auth.jwt.JwtValidator;
+import com.notitime.noffice.global.config.SecurityWhiteListPaths;
 import com.notitime.noffice.global.exception.UnauthorizedException;
 import com.notitime.noffice.global.response.BusinessErrorCode;
 import jakarta.servlet.FilterChain;
@@ -17,6 +18,8 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -26,10 +29,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	public static final String BEARER = "Bearer ";
 	private final JwtValidator jwtValidator;
 	private final JwtProvider jwtProvider;
+	private final PathMatcher pathMatcher = new AntPathMatcher();
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
 			throws ServletException, IOException {
+		if (SecurityWhiteListPaths.isWhitelisted(request)) {
+			filterChain.doFilter(request, response);
+			return;
+		}
 		final String accessToken = getAccessToken(request);
 		jwtValidator.validateAccessToken(accessToken);
 		doAuthentication(request, jwtProvider.getSubject(accessToken));

--- a/src/main/java/com/notitime/noffice/global/config/SecurityConfig.java
+++ b/src/main/java/com/notitime/noffice/global/config/SecurityConfig.java
@@ -31,29 +31,26 @@ public class SecurityConfig {
 	private final JwtValidator jwtValidator;
 	private final JwtProvider jwtProvider;
 
-	private static final String[] whiteList = {"/api/v1/**",
-			"/health", "/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**", "/webjars/**", "/h2-console/**"};
-
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		return http
 				.csrf(AbstractHttpConfigurer::disable)
 				.formLogin(AbstractHttpConfigurer::disable)
 				.httpBasic(AbstractHttpConfigurer::disable)
+				.cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource()))
 				.sessionManagement(sessionManagementConfigurer ->
 						sessionManagementConfigurer
 								.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+				.authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
+						authorizationManagerRequestMatcherRegistry.requestMatchers(
+										SecurityWhiteListPaths.SECURITY_WHITE_LIST).permitAll()
+								.anyRequest().authenticated())
 				.exceptionHandling(exceptionHandlingConfigurer ->
 						exceptionHandlingConfigurer
 								.authenticationEntryPoint(jwtAuthenticationEntryPoint))
-				.authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
-						authorizationManagerRequestMatcherRegistry
-								.requestMatchers(whiteList).permitAll()
-								.anyRequest().authenticated())
 				.addFilterBefore(new JwtAuthenticationFilter(jwtValidator, jwtProvider),
 						UsernamePasswordAuthenticationFilter.class)
 				.addFilterBefore(new ExceptionHandlerFilter(), JwtAuthenticationFilter.class)
-				.cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource()))
 				.build();
 	}
 

--- a/src/main/java/com/notitime/noffice/global/config/SecurityWhiteListPaths.java
+++ b/src/main/java/com/notitime/noffice/global/config/SecurityWhiteListPaths.java
@@ -1,5 +1,6 @@
 package com.notitime.noffice.global.config;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
@@ -29,4 +30,9 @@ public class SecurityWhiteListPaths {
 			"/webjars/**",
 			"/h2-console/**"
 	};
+
+	public static boolean isWhitelisted(HttpServletRequest request) {
+		String path = request.getRequestURI();
+		return FILTER_WHITE_LIST.stream().anyMatch(pattern -> pathMatcher.match(pattern, path));
+	}
 }

--- a/src/main/java/com/notitime/noffice/global/config/SecurityWhiteListPaths.java
+++ b/src/main/java/com/notitime/noffice/global/config/SecurityWhiteListPaths.java
@@ -1,0 +1,32 @@
+package com.notitime.noffice.global.config;
+
+import java.util.List;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
+
+public class SecurityWhiteListPaths {
+	private static final PathMatcher pathMatcher = new AntPathMatcher();
+	public static final List<String> FILTER_WHITE_LIST = List.of(
+			"/health",
+			"/api/v1/**",
+			"/swagger-ui/**",
+			"/swagger-resources/**",
+			"/api-docs/**",
+			"/v3/api-docs/**",
+			"/webjars/**",
+			"/h2-console/**"
+	);
+
+	public static final String[] SECURITY_WHITE_LIST = {
+			"/health",
+			"/api/v1/**",
+			"/v1/user/**",
+			"/error",
+			"/swagger-ui/**",
+			"/swagger-resources/**",
+			"/api-docs/**",
+			"/v3/api-docs/**",
+			"/webjars/**",
+			"/h2-console/**"
+	};
+}

--- a/src/main/java/com/notitime/noffice/global/response/NofficeResponse.java
+++ b/src/main/java/com/notitime/noffice/global/response/NofficeResponse.java
@@ -17,7 +17,7 @@ public class NofficeResponse<T> {
 
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm:ss", timezone = "Asia/Seoul")
 	@JsonProperty("timestamp")
-	private final LocalDateTime timestamp = LocalDateTime.now();
+	private final String timestamp = LocalDateTime.now().toString();
 	private final int httpStatus;
 
 	private final String code;


### PR DESCRIPTION
## 🚀 Related Issue

## 📌 Tasks

- 웹 요청의 보안 토큰 검증 security 로직 추가에 따른 whitelist 요청 검증을 구현했습니다.

## 📝 Details

- `SecurityWhiteListPaths` 내 아래 두 관리 대상을 추가하였습니다. 
 - `FILTER_WHITE_LIST` : `JwtAuthenticationFilter`, `JwtAuthenticationEntryPoint` 내에서 검증되며, 인가 여부에 관계없이 whitelist에 등록된 uri인 경우 요청을 pass 시킵니다. 모든 사용자가 접근 가능한 endpoint를 명시합니다. (검증 로직 pass)

 -  `SECURITY_WHITE_LIST` : App 단 `SecurityFilterChain`에서 검증되며, 토큰이 동봉된 요청을 기대합니다. 
   - `SecurityConfig`에서 구성된 filter를 거치나, jwt 인증만 pass 합니다.

## 📚 Remarks

- 배포 후 db 분리 시 FILTER_WHITE_LIST 역시 인증이 필요한 uri는 제한될 수 있습니다.