### PR TITLE
✨ [Feat] 노티 생성, 수정, 조회, 삭제 기능 구현

### DIFF
--- a/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
@@ -1,0 +1,32 @@
+package com.notitime.noffice.api.announcement.business;
+
+import com.notitime.noffice.api.announcement.persistence.AnnouncementRepository;
+import com.notitime.noffice.domain.Announcement;
+import com.notitime.noffice.global.exception.NotFoundException;
+import com.notitime.noffice.global.response.BusinessErrorCode;
+import com.notitime.noffice.response.AnnouncementResponse;
+import com.notitime.noffice.response.AnnouncementResponses;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AnnouncementService {
+
+	private final AnnouncementRepository announcementRepository;
+
+	@Transactional(readOnly = true)
+	public AnnouncementResponse getAnnouncement(final Long announcementId) {
+		return AnnouncementResponse.of(announcementRepository.findById(announcementId)
+				.orElseThrow(() -> new NotFoundException(BusinessErrorCode.NOT_FOUND_ANNOUNCEMENT)));
+	}
+
+	@Transactional(readOnly = true)
+	public AnnouncementResponses getAnnouncements() {
+		List<Announcement> announcements = announcementRepository.findAll();
+		return AnnouncementResponses.of(announcements.stream().map(AnnouncementResponse::of).toList());
+	}
+}

--- a/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
@@ -5,6 +5,7 @@ import com.notitime.noffice.domain.Announcement;
 import com.notitime.noffice.global.exception.NotFoundException;
 import com.notitime.noffice.global.response.BusinessErrorCode;
 import com.notitime.noffice.request.AnnouncementCreateRequest;
+import com.notitime.noffice.request.AnnouncementUpdateRequest;
 import com.notitime.noffice.response.AnnouncementResponse;
 import com.notitime.noffice.response.AnnouncementResponses;
 import java.time.LocalDateTime;
@@ -41,5 +42,16 @@ public class AnnouncementService {
 				request.placeLinkName(),
 				request.placeLinkUrl(),
 				LocalDateTime.parse(request.endAt(), Announcement.DATE_TIME_FORMATTER)));
+	}
+
+	public AnnouncementResponse updateAnnouncement(final Long announcementId,
+	                                               final AnnouncementUpdateRequest announcementCreateRequest) {
+		Announcement existAnnouncement = announcementRepository.findById(announcementId).orElseThrow(
+				() -> new NotFoundException(BusinessErrorCode.NOT_FOUND_ANNOUNCEMENT));
+		return AnnouncementResponse.of(announcementRepository.save(existAnnouncement));
+	}
+
+	public void deleteAnnouncement(final Long announcementId) {
+		announcementRepository.deleteById(announcementId);
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
@@ -4,8 +4,10 @@ import com.notitime.noffice.api.announcement.persistence.AnnouncementRepository;
 import com.notitime.noffice.domain.Announcement;
 import com.notitime.noffice.global.exception.NotFoundException;
 import com.notitime.noffice.global.response.BusinessErrorCode;
+import com.notitime.noffice.request.AnnouncementCreateRequest;
 import com.notitime.noffice.response.AnnouncementResponse;
 import com.notitime.noffice.response.AnnouncementResponses;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,5 +30,16 @@ public class AnnouncementService {
 	public AnnouncementResponses getAnnouncements() {
 		List<Announcement> announcements = announcementRepository.findAll();
 		return AnnouncementResponses.of(announcements.stream().map(AnnouncementResponse::of).toList());
+	}
+
+	public AnnouncementResponse createAnnouncement(final AnnouncementCreateRequest request) {
+		return AnnouncementResponse.of(Announcement.createAnnouncement(
+				request.title(),
+				request.content(),
+				request.profileImageUrl(),
+				request.isFaceToFace(),
+				request.placeLinkName(),
+				request.placeLinkUrl(),
+				LocalDateTime.parse(request.endAt(), Announcement.DATE_TIME_FORMATTER)));
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/announcement/persistence/AnnouncementRepository.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/persistence/AnnouncementRepository.java
@@ -1,0 +1,7 @@
+package com.notitime.noffice.api.announcement.persistence;
+
+import com.notitime.noffice.domain.Announcement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
+}

--- a/src/main/java/com/notitime/noffice/api/announcement/presentation/AnnouncementController.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/presentation/AnnouncementController.java
@@ -1,0 +1,81 @@
+package com.notitime.noffice.api.announcement.presentation;
+
+import com.notitime.noffice.api.announcement.business.AnnouncementService;
+import com.notitime.noffice.global.response.BusinessSuccessCode;
+import com.notitime.noffice.global.response.NofficeResponse;
+import com.notitime.noffice.request.AnnouncementCreateRequest;
+import com.notitime.noffice.request.AnnouncementUpdateRequest;
+import com.notitime.noffice.response.AnnouncementResponse;
+import com.notitime.noffice.response.AnnouncementResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "노티", description = "노티(공지사항) CRUD API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/announcement")
+public class AnnouncementController {
+
+	private final AnnouncementService announcementService;
+
+	@Operation(summary = "모든 노티 조회", description = "사용자에게 할당된 모든 노티를 조회합니다.", responses = {
+			@ApiResponse(responseCode = "NOF-2051", description = "노티 목록 조회 성공"),
+			@ApiResponse(responseCode = "NOF-404", description = "등록된 노티가 없습니다.")
+	})
+	@GetMapping
+	public NofficeResponse<AnnouncementResponses> getAnnouncements() {
+		return NofficeResponse.success(BusinessSuccessCode.GET_ANNOUNCEMENTS_SUCCESS,
+				announcementService.getAnnouncements());
+	}
+
+	@Operation(summary = "노티 생성", description = "노티를 생성합니다.", responses = {
+			@ApiResponse(responseCode = "NOF-2150", description = "노티 생성 성공"),
+			@ApiResponse(responseCode = "NOF-400", description = "노티 생성 실패")
+	})
+	@PostMapping
+	public NofficeResponse<AnnouncementResponse> createAnnouncement(
+			@RequestBody final AnnouncementCreateRequest announcementCreateRequest) {
+		return NofficeResponse.success(BusinessSuccessCode.POST_ANNOUNCEMENT_SUCCESS,
+				announcementService.createAnnouncement(announcementCreateRequest));
+	}
+
+	@Operation(summary = "노티 조회", description = "노티를 조회합니다.", responses = {
+			@ApiResponse(responseCode = "NOF-2050", description = "노티 단일 조회 성공"),
+			@ApiResponse(responseCode = "NOF-404", description = "해당 노티가 없습니다.")
+	})
+	@GetMapping("/{announcementId}")
+	public NofficeResponse<AnnouncementResponse> getAnnouncement(@PathVariable final Long announcementId) {
+		return NofficeResponse.success(BusinessSuccessCode.GET_ANNOUNCEMENT_SUCCESS,
+				announcementService.getAnnouncement(announcementId));
+	}
+
+	@Operation(summary = "노티 수정", description = "노티를 수정합니다.", responses = {
+			@ApiResponse(responseCode = "NOF-2052", description = "노티 수정 성공"),
+			@ApiResponse(responseCode = "NOF-404", description = "해당 노티가 없습니다.")
+	})
+	@PostMapping("/{announcementId}")
+	public NofficeResponse<AnnouncementResponse> updateAnnouncement(@PathVariable final Long announcementId,
+	                                                                @RequestBody final AnnouncementUpdateRequest announcementUpdateRequest) {
+		return NofficeResponse.success(BusinessSuccessCode.PUT_ANNOUNCEMENT_SUCCESS,
+				announcementService.updateAnnouncement(announcementId, announcementUpdateRequest));
+	}
+
+	@Operation(summary = "노티 삭제", description = "노티를 삭제합니다.", responses = {
+			@ApiResponse(responseCode = "NOF-2053", description = "노티 삭제 성공"),
+			@ApiResponse(responseCode = "NOF-404", description = "노티 삭제에 실패하였습니다.")
+	})
+	@DeleteMapping("/{announcementId}")
+	public NofficeResponse<Void> deleteAnnouncement(@PathVariable final Long announcementId) {
+		announcementService.deleteAnnouncement(announcementId);
+		return NofficeResponse.success(BusinessSuccessCode.DELETE_ANNOUNCEMENT_SUCCESS);
+	}
+}

--- a/src/main/java/com/notitime/noffice/domain/Announcement.java
+++ b/src/main/java/com/notitime/noffice/domain/Announcement.java
@@ -15,11 +15,15 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
 @Getter
 public class Announcement extends BaseTimeEntity {
 
@@ -46,9 +50,11 @@ public class Announcement extends BaseTimeEntity {
 
 	private LocalDateTime endAt;
 
+	@Builder.Default
 	@OneToMany(mappedBy = "announcement", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Task> tasks = new ArrayList<>();
 
+	@Builder.Default
 	@OneToMany(mappedBy = "announcement", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Notification> notifications = new ArrayList<>();
 
@@ -59,4 +65,18 @@ public class Announcement extends BaseTimeEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "organization_id")
 	private Organization organization;
+
+	public static Announcement createAnnouncement(String title, String content, String profileImageUrl,
+	                                              boolean isFaceToFace,
+	                                              String placeLinkName, String placeLinkUrl, LocalDateTime endAt) {
+		return Announcement.builder()
+				.title(title)
+				.content(content)
+				.profileImageUrl(profileImageUrl)
+				.isFaceToFace(isFaceToFace)
+				.placeLinkName(placeLinkName)
+				.placeLinkUrl(placeLinkUrl)
+				.endAt(endAt)
+				.build();
+	}
 }

--- a/src/main/java/com/notitime/noffice/global/response/BusinessErrorCode.java
+++ b/src/main/java/com/notitime/noffice/global/response/BusinessErrorCode.java
@@ -36,6 +36,7 @@ public enum BusinessErrorCode implements ErrorCode {
 
 	// 404 Not Found
 	NOT_FOUND(HttpStatus.NOT_FOUND, "NOF-404", "리소스를 찾을 수 없습니다."),
+	NOT_FOUND_ANNOUNCEMENT(HttpStatus.NOT_FOUND, "NOF-4450", "공지사항을 찾을 수 없습니다."),
 	STORE_FILE_SIZE_EXCEEDED(HttpStatus.NOT_FOUND, "NOF-404", "업로드 가능한 파일 크기를 초과했습니다.");
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/notitime/noffice/global/response/BusinessSuccessCode.java
+++ b/src/main/java/com/notitime/noffice/global/response/BusinessSuccessCode.java
@@ -16,14 +16,20 @@ public enum BusinessSuccessCode implements SuccessCode {
 	GET_JOINED_ORGANIZATIONS_SUCCESS(HttpStatus.OK, "NOF-2002", "회원의 가입된 조직 조회에 성공하였습니다."),
 	GET_ORGANIZATION_SUCCESS(HttpStatus.OK, "NOF-2003", "조직 정보 조회에 성공하였습니다."),
 	GET_CATEGORY_SUCCESS(HttpStatus.OK, "NOF-2004", "카테고리 조회에 성공하였습니다."),
+	GET_ANNOUNCEMENT_SUCCESS(HttpStatus.OK, "NOF-2050", "노티 단일 조회에 성공하였습니다."),
+	GET_ANNOUNCEMENTS_SUCCESS(HttpStatus.OK, "NOF-2051", "노티 목록 조회에 성공하였습니다."),
+	PUT_ANNOUNCEMENT_SUCCESS(HttpStatus.OK, "NOF-2052", "노티 수정에 성공하였습니다."),
+
 
 	// CREATED (2100 ~ 2199)
 	CREATED(HttpStatus.CREATED, "NOF-210", "리소스가 생성되었습니다. - 201"),
 	POST_ORGANIZATION_SUCCESS(HttpStatus.CREATED, "NOF-2100", "조직 생성에 성공하였습니다."),
 	POST_JOIN_ORGANIZATION_SUCCESS(HttpStatus.CREATED, "NOF-2101", "조직 가입에 성공하였습니다."),
+	POST_ANNOUNCEMENT_SUCCESS(HttpStatus.CREATED, "NOF-2150", "노티 생성에 성공하였습니다."),
 
 	// NO CONTENT (2400 ~ 2499)
 	NO_CONTENT(HttpStatus.NO_CONTENT, "NOF-2400", "요청이 성공했습니다. - 204"),
+	DELETE_ANNOUNCEMENT_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2053", "노티 삭제에 성공하였습니다."),
 
 	// RESET CONTENT (2500 ~ 2599)
 	RESET_CONTENT(HttpStatus.RESET_CONTENT, "NOF-205", "리소스가 갱신되었습니다. - 205");

--- a/src/main/java/com/notitime/noffice/request/AnnouncementCreateRequest.java
+++ b/src/main/java/com/notitime/noffice/request/AnnouncementCreateRequest.java
@@ -1,0 +1,19 @@
+package com.notitime.noffice.request;
+
+import com.notitime.noffice.response.TaskCreateRequest;
+import java.util.List;
+
+public record AnnouncementCreateRequest(
+		Long organizationId,
+		Long memberId,
+		String title,
+		String content,
+		String profileImageUrl,
+		String placeLinkName,
+		String placeLinkUrl,
+		Boolean isFaceToFace,
+		List<TaskCreateRequest> tasks,
+		String endAt,
+		List<String> noticeBefore,
+		List<String> noticeDate) {
+}

--- a/src/main/java/com/notitime/noffice/request/AnnouncementUpdateRequest.java
+++ b/src/main/java/com/notitime/noffice/request/AnnouncementUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.notitime.noffice.request;
+
+import com.notitime.noffice.response.TaskCreateRequest;
+import java.util.List;
+
+public record AnnouncementUpdateRequest(
+		Long organizationId,
+		Long memberId,
+		String title,
+		String content,
+		String profileImageUrl,
+		String placeLinkName,
+		String placeLinkUrl,
+		Boolean isFaceToFace,
+		List<TaskCreateRequest> tasks,
+		String endAt,
+		List<String> noticeBefore,
+		List<String> noticeDate) {
+}

--- a/src/main/java/com/notitime/noffice/response/AnnouncementResponse.java
+++ b/src/main/java/com/notitime/noffice/response/AnnouncementResponse.java
@@ -1,0 +1,39 @@
+package com.notitime.noffice.response;
+
+import com.notitime.noffice.domain.Announcement;
+import com.notitime.noffice.domain.Notification;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AnnouncementResponse(
+		Long organizationId,
+		Long memberId,
+		Long announcementId,
+		String title,
+		String content,
+		String profileImageUrl,
+		String placeLinkName,
+		String placeLinkUrl,
+		LocalDateTime endAt,
+		List<LocalDateTime> noticeAt,
+		LocalDateTime createdAt,
+		LocalDateTime updatedAt
+) {
+
+	public static AnnouncementResponse of(Announcement announcement) {
+		return new AnnouncementResponse(
+				announcement.getOrganization().getId(),
+				announcement.getMember().getId(),
+				announcement.getId(),
+				announcement.getTitle(),
+				announcement.getContent(),
+				announcement.getProfileImageUrl(),
+				announcement.getPlaceLinkName(),
+				announcement.getPlaceLinkUrl(),
+				announcement.getEndAt(),
+				announcement.getNotifications().stream()
+						.map(Notification::getSendAt).toList(),
+				announcement.getCreatedAt(),
+				announcement.getUpdatedAt());
+	}
+}

--- a/src/main/java/com/notitime/noffice/response/AnnouncementResponses.java
+++ b/src/main/java/com/notitime/noffice/response/AnnouncementResponses.java
@@ -1,0 +1,9 @@
+package com.notitime.noffice.response;
+
+import java.util.List;
+
+public record AnnouncementResponses(List<AnnouncementResponse> announcements) {
+	public static AnnouncementResponses of(List<AnnouncementResponse> announcements) {
+		return new AnnouncementResponses(announcements);
+	}
+}

--- a/src/main/java/com/notitime/noffice/response/NotificationResponse.java
+++ b/src/main/java/com/notitime/noffice/response/NotificationResponse.java
@@ -1,0 +1,4 @@
+package com.notitime.noffice.response;
+
+public record NotificationResponse(Long id) {
+}

--- a/src/main/java/com/notitime/noffice/response/TaskCreateRequest.java
+++ b/src/main/java/com/notitime/noffice/response/TaskCreateRequest.java
@@ -1,0 +1,4 @@
+package com.notitime.noffice.response;
+
+public record TaskCreateRequest(String content) {
+}


### PR DESCRIPTION
## 🚀 Related Issue

close: #40 #41 #42 #43 #44

## 📌 Tasks

- 노티 (조직 내 공지 게시글) 발행 및 관리를 위한 API를 구현하였습니다.
- 노티 전체 목록 조회 : GET : /api/v1/announcement
- 노티 단일 조회 : GET : /api/v1/announcement/{announcementId} 
- 노티 생성 : POST : /api/v1/announcement
- 노티 삭제 : GET : /api/v1/announcement/{announcementId}

## 📝 Details

- 인가받은 사용자만 접근할 수 있도록 `LoginUserArgumentResolver`에 의한 요청 제한을 추가해야 합니다.
- 노티 목록 조회 (#44)의 경우 사용자가 가입된 조직만 조회할 수 있도록 변경해야 합니다.

## 📚 Remarks

- 로직 검증을 위해 가능한 단위 테스트는 시행해야 할 것 같습니다.. 😿