### PR TITLE
♻️ [Refactor] Web schemas Nullable serializer 추가 

### DIFF
--- a/src/main/java/com/notitime/noffice/api/task/presentation/TaskApi.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/TaskApi.java
@@ -2,7 +2,7 @@ package com.notitime.noffice.api.task.presentation;
 
 import com.notitime.noffice.global.response.NofficeResponse;
 import com.notitime.noffice.request.TaskBulkCreateRequest;
-import com.notitime.noffice.response.TaskCreateRequest;
+import com.notitime.noffice.request.TaskCreateRequest;
 import com.notitime.noffice.response.TaskCreateResponse;
 import com.notitime.noffice.response.TaskCreateResponses;
 import com.notitime.noffice.response.TaskResponses;

--- a/src/main/java/com/notitime/noffice/api/task/presentation/TaskController.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/TaskController.java
@@ -3,7 +3,7 @@ package com.notitime.noffice.api.task.presentation;
 import com.notitime.noffice.global.response.BusinessSuccessCode;
 import com.notitime.noffice.global.response.NofficeResponse;
 import com.notitime.noffice.request.TaskBulkCreateRequest;
-import com.notitime.noffice.response.TaskCreateRequest;
+import com.notitime.noffice.request.TaskCreateRequest;
 import com.notitime.noffice.response.TaskCreateResponse;
 import com.notitime.noffice.response.TaskCreateResponses;
 import com.notitime.noffice.response.TaskResponses;

--- a/src/main/java/com/notitime/noffice/request/AnnouncementCreateRequest.java
+++ b/src/main/java/com/notitime/noffice/request/AnnouncementCreateRequest.java
@@ -3,7 +3,6 @@ package com.notitime.noffice.request;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.notitime.noffice.response.TaskCreateRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import java.util.List;

--- a/src/main/java/com/notitime/noffice/request/AnnouncementCreateRequest.java
+++ b/src/main/java/com/notitime/noffice/request/AnnouncementCreateRequest.java
@@ -1,19 +1,32 @@
 package com.notitime.noffice.request;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.notitime.noffice.response.TaskCreateRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import java.util.List;
 
+@JsonInclude(NON_NULL)
 public record AnnouncementCreateRequest(
-		Long organizationId,
-		Long memberId,
-		String title,
-		String content,
-		String profileImageUrl,
-		String placeLinkName,
-		String placeLinkUrl,
-		Boolean isFaceToFace,
-		List<TaskCreateRequest> tasks,
-		String endAt,
-		List<String> noticeBefore,
-		List<String> noticeDate) {
+		@Schema(requiredMode = RequiredMode.REQUIRED, example = "조직 ID") Long organizationId,
+		@Schema(requiredMode = RequiredMode.REQUIRED, example = "1") Long memberId,
+		@Schema(requiredMode = RequiredMode.REQUIRED, example = "공지 제목") String title,
+		@Schema(requiredMode = RequiredMode.REQUIRED, example = "공지 내용") String content,
+		@Schema(requiredMode = RequiredMode.NOT_REQUIRED, example = "프로필 이미지 URL") String profileImageUrl,
+		@Schema(requiredMode = RequiredMode.NOT_REQUIRED, example = "장소 링크 이름") String placeLinkName,
+		@Schema(requiredMode = RequiredMode.NOT_REQUIRED, example = "장소 링크 URL") String placeLinkUrl,
+		@Schema(requiredMode = RequiredMode.NOT_REQUIRED, example = "true") Boolean isFaceToFace,
+		@Schema(requiredMode = RequiredMode.NOT_REQUIRED) List<TaskCreateRequest> tasks,
+		@Schema(requiredMode = RequiredMode.REQUIRED, example = "2021-07-01T 00:00:00") String endAt,
+		@Schema(requiredMode = RequiredMode.REQUIRED, example = "[2021-07-01T00:00:00, 2021-07-02T00:00:00]") List<String> noticeBefore,
+		@Schema(requiredMode = RequiredMode.REQUIRED) List<String> noticeDate) {
+	public AnnouncementCreateRequest {
+		profileImageUrl = (profileImageUrl != null && profileImageUrl.isEmpty()) ? null : profileImageUrl;
+		placeLinkName = (placeLinkName != null && placeLinkName.isEmpty()) ? null : placeLinkName;
+		placeLinkUrl = (placeLinkUrl != null && placeLinkUrl.isEmpty()) ? null : placeLinkUrl;
+		isFaceToFace = (isFaceToFace != null) ? isFaceToFace : false;
+		tasks = (tasks != null && tasks.isEmpty()) ? null : tasks;
+	}
 }

--- a/src/main/java/com/notitime/noffice/request/AnnouncementUpdateRequest.java
+++ b/src/main/java/com/notitime/noffice/request/AnnouncementUpdateRequest.java
@@ -1,19 +1,28 @@
 package com.notitime.noffice.request;
 
 import com.notitime.noffice.response.TaskCreateRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import java.util.List;
 
 public record AnnouncementUpdateRequest(
-		Long organizationId,
-		Long memberId,
-		String title,
-		String content,
-		String profileImageUrl,
-		String placeLinkName,
-		String placeLinkUrl,
-		Boolean isFaceToFace,
-		List<TaskCreateRequest> tasks,
-		String endAt,
-		List<String> noticeBefore,
-		List<String> noticeDate) {
+		@Schema(requiredMode = RequiredMode.REQUIRED, example = "조직 ID") Long organizationId,
+		@Schema(requiredMode = RequiredMode.REQUIRED, example = "1") Long memberId,
+		@Schema(requiredMode = RequiredMode.REQUIRED, example = "공지 제목") String title,
+		@Schema(requiredMode = RequiredMode.REQUIRED, example = "공지 내용") String content,
+		@Schema(requiredMode = RequiredMode.NOT_REQUIRED, example = "프로필 이미지 URL") String profileImageUrl,
+		@Schema(requiredMode = RequiredMode.NOT_REQUIRED, example = "장소 링크 이름") String placeLinkName,
+		@Schema(requiredMode = RequiredMode.NOT_REQUIRED, example = "장소 링크 URL") String placeLinkUrl,
+		@Schema(requiredMode = RequiredMode.NOT_REQUIRED, example = "true") Boolean isFaceToFace,
+		@Schema(requiredMode = RequiredMode.NOT_REQUIRED) List<TaskCreateRequest> tasks,
+		@Schema(requiredMode = RequiredMode.REQUIRED, example = "2021-07-01T 00:00:00") String endAt,
+		@Schema(requiredMode = RequiredMode.REQUIRED, example = "[2021-07-01T00:00:00, 2021-07-02T00:00:00]") List<String> noticeBefore,
+		@Schema(requiredMode = RequiredMode.REQUIRED) List<String> noticeDate) {
+	public AnnouncementUpdateRequest {
+		profileImageUrl = (profileImageUrl != null && profileImageUrl.isEmpty()) ? null : profileImageUrl;
+		placeLinkName = (placeLinkName != null && placeLinkName.isEmpty()) ? null : placeLinkName;
+		placeLinkUrl = (placeLinkUrl != null && placeLinkUrl.isEmpty()) ? null : placeLinkUrl;
+		isFaceToFace = (isFaceToFace != null) ? isFaceToFace : false;
+		tasks = (tasks != null && tasks.isEmpty()) ? null : tasks;
+	}
 }

--- a/src/main/java/com/notitime/noffice/request/AnnouncementUpdateRequest.java
+++ b/src/main/java/com/notitime/noffice/request/AnnouncementUpdateRequest.java
@@ -1,6 +1,5 @@
 package com.notitime.noffice.request;
 
-import com.notitime.noffice.response.TaskCreateRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import java.util.List;

--- a/src/main/java/com/notitime/noffice/request/CategoryRequest.java
+++ b/src/main/java/com/notitime/noffice/request/CategoryRequest.java
@@ -4,6 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 public record CategoryRequest(
-		@Schema(description = "카테고리 아이디 리스트", example = "1,3,5")
+		@Schema(requiredMode = Schema.RequiredMode.REQUIRED, example = "[1, 2]", description = "카테고리 ID 목록")
 		List<Long> categoryIds) {
 }

--- a/src/main/java/com/notitime/noffice/request/NotificationRequest.java
+++ b/src/main/java/com/notitime/noffice/request/NotificationRequest.java
@@ -1,6 +1,18 @@
 package com.notitime.noffice.request;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import java.time.LocalDateTime;
 
-public record NotificationRequest(String title, String content, Long memberId, LocalDateTime sendAt) {
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record NotificationRequest(
+		@Schema(requiredMode = RequiredMode.REQUIRED, example = "알림 제목") String title,
+		@Schema(requiredMode = RequiredMode.NOT_REQUIRED, example = "알림 내용") String content,
+		@Schema(requiredMode = RequiredMode.REQUIRED, example = "1") Long memberId,
+		@Schema(requiredMode = RequiredMode.REQUIRED, example = "2021-07-01T00:00:00") LocalDateTime sendAt
+) {
+	public NotificationRequest {
+		content = (content != null && content.isEmpty()) ? null : content;
+	}
 }

--- a/src/main/java/com/notitime/noffice/request/NotificationTimeChangeRequest.java
+++ b/src/main/java/com/notitime/noffice/request/NotificationTimeChangeRequest.java
@@ -1,6 +1,15 @@
 package com.notitime.noffice.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import java.util.List;
 
-public record NotificationTimeChangeRequest(Long announcementId, List<String> noticeBefore, List<String> noticeDate) {
+public record NotificationTimeChangeRequest(
+		@Schema(requiredMode = Schema.RequiredMode.REQUIRED, example = "1", description = "공지 ID")
+		Long announcementId,
+		@Schema(requiredMode = RequiredMode.REQUIRED, description = "알림 시간 변경 초(second)", example = "60, 120, 180")
+		List<String> noticeBefore,
+
+		@Schema(requiredMode = RequiredMode.REQUIRED, description = "알림 시간 변경 기준 일자", example = "[\"2021-07-01T00:00:00\", \"2021-07-02T00:00:00\"]")
+		List<String> noticeDate) {
 }

--- a/src/main/java/com/notitime/noffice/request/OrganizationCreateRequest.java
+++ b/src/main/java/com/notitime/noffice/request/OrganizationCreateRequest.java
@@ -1,21 +1,24 @@
 package com.notitime.noffice.request;
 
-import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotNull;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
-import org.springframework.format.annotation.DateTimeFormat;
 
 public record OrganizationCreateRequest(
-		@NotNull(message = "그룹의 이름을 입력해주세요.")
+		@Schema(requiredMode = REQUIRED, example = "조직 이름", description = "조직 이름")
 		String name,
-		@NotNull(message = "그룹의 카테고리를 선택해주세요.")
+		@Schema(requiredMode = REQUIRED, description = "조직 분류 ID 목록")
 		CategoryRequest categories,
-		@Nullable
+		@Schema(requiredMode = REQUIRED, example = "https://test-image.com/cover_image.jpg", description = "조직 커버 이미지 URL")
 		String profile_image,
-		@DateTimeFormat(pattern = "yyyy-MM-dd")
-		@Nullable
-		LocalDate organizationEndAt,
-		@Nullable
-		String promotion_code
+		@Schema(requiredMode = REQUIRED, description = "조직 활동 마감일자", example = "2021-07-01")
+		LocalDate endAt,
+		@Schema(requiredMode = NOT_REQUIRED, description = "프로모션 코드 문자열", example = "NOFFICE_HART")
+		String promotionCode
 ) {
+	public OrganizationCreateRequest {
+		promotionCode = (promotionCode != null && promotionCode.isEmpty()) ? null : promotionCode;
+	}
 }

--- a/src/main/java/com/notitime/noffice/request/OrganizationJoinRequest.java
+++ b/src/main/java/com/notitime/noffice/request/OrganizationJoinRequest.java
@@ -1,9 +1,12 @@
 package com.notitime.noffice.request;
 
-import io.swagger.v3.oas.annotations.Parameter;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
-public record OrganizationJoinRequest(@Parameter(description = "멤버 ID", required = true)
-                                      Long memberId, Long organizationId) {
+import io.swagger.v3.oas.annotations.media.Schema;
 
-
+public record OrganizationJoinRequest(
+		@Schema(description = "사용자 ID", example = "1", requiredMode = REQUIRED)
+		Long memberId,
+		@Schema(description = "조직 ID", example = "1", requiredMode = REQUIRED)
+		Long organizationId) {
 }

--- a/src/main/java/com/notitime/noffice/request/SocialAuthRequest.java
+++ b/src/main/java/com/notitime/noffice/request/SocialAuthRequest.java
@@ -1,9 +1,15 @@
 package com.notitime.noffice.request;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import com.notitime.noffice.domain.SocialAuthProvider;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record SocialAuthRequest(
+		@Schema(description = "소셜 로그인 제공자", example = "APPLE", requiredMode = REQUIRED)
 		SocialAuthProvider provider,
+
+		@Schema(description = "제공자로부터 얻은 사용자별 인가 코드", example = "1q2w3e4r", requiredMode = REQUIRED)
 		String code
 ) {
 	public static SocialAuthRequest of(SocialAuthProvider provider, String code) {

--- a/src/main/java/com/notitime/noffice/request/TaskBulkCreateRequest.java
+++ b/src/main/java/com/notitime/noffice/request/TaskBulkCreateRequest.java
@@ -1,6 +1,11 @@
 package com.notitime.noffice.request;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
-public record TaskBulkCreateRequest(List<String> contents) {
+public record TaskBulkCreateRequest(
+		@Schema(description = "투두 항목 목록", example = "[\"노피스 API 제작\", \"노피스 API 문서 작성\"]", requiredMode = REQUIRED)
+		List<String> contents) {
 }

--- a/src/main/java/com/notitime/noffice/request/TaskCreateRequest.java
+++ b/src/main/java/com/notitime/noffice/request/TaskCreateRequest.java
@@ -1,0 +1,10 @@
+package com.notitime.noffice.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TaskCreateRequest(
+		@Schema(description = "투두 항목", example = "노피스 API 제작", requiredMode = REQUIRED)
+		String content) {
+}

--- a/src/main/java/com/notitime/noffice/response/TaskCreateRequest.java
+++ b/src/main/java/com/notitime/noffice/response/TaskCreateRequest.java
@@ -1,4 +1,0 @@
-package com.notitime.noffice.response;
-
-public record TaskCreateRequest(String content) {
-}


### PR DESCRIPTION
## 🚀 Related Issue

close: #51 

## 📌 Tasks

- Web request schemas 필드별 예시 케이스 기술
- record 내 nullable 관련 필드가 null로 들어온 경우 dto 단에서 null로 부여된 불변 객체를 생성하도록 설정

## 📝 Details

## 📚 Remarks

- nullable space에 특정 상태에 의한 null이 부여되는 경우를 추가 고려할 수 있음 (~한 사유에 의한 미입력 등)