### PR TITLE
♻️ [Refactor] 공지 생성 API 생성자 리팩토링

### DIFF
--- a/src/main/java/com/notitime/noffice/api/member/business/MemberService.java
+++ b/src/main/java/com/notitime/noffice/api/member/business/MemberService.java
@@ -19,14 +19,16 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 	private final OrganizationService organizationService;
 
-
 	public MemberResponse getMember(Long memberId) {
-		Member member = memberRepository.findById(memberId)
-				.orElseThrow(() -> new NotFoundException(BusinessErrorCode.NOT_FOUND));
-		return MemberResponse.of(member);
+		return MemberResponse.of(getMemberEntity(memberId));
 	}
 
 	public OrganizationResponses getJoinedOrganizations(Long memberId) {
 		return organizationService.getOrganizationsByMemberId(memberId);
+	}
+
+	public Member getMemberEntity(Long memberId) {
+		return memberRepository.findById(memberId)
+				.orElseThrow(() -> new NotFoundException(BusinessErrorCode.NOT_FOUND));
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/organization/business/OrganizationService.java
+++ b/src/main/java/com/notitime/noffice/api/organization/business/OrganizationService.java
@@ -1,6 +1,11 @@
 package com.notitime.noffice.api.organization.business;
 
+import com.notitime.noffice.domain.organization.model.Organization;
 import com.notitime.noffice.domain.organization.persistence.OrganizationMemberRepository;
+import com.notitime.noffice.domain.organization.persistence.OrganizationRepository;
+import com.notitime.noffice.global.exception.NotFoundException;
+import com.notitime.noffice.global.response.BusinessErrorCode;
+import com.notitime.noffice.response.OrganizationResponse;
 import com.notitime.noffice.response.OrganizationResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,8 +17,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrganizationService {
 
 	private final OrganizationMemberRepository organizationMemberRepository;
+	private final OrganizationRepository organizationRepository;
+
+	public OrganizationResponse getOrganization(Long organizationId) {
+		return OrganizationResponse.of(getOrganizationEntity(organizationId));
+	}
 
 	public OrganizationResponses getOrganizationsByMemberId(Long memberId) {
 		return OrganizationResponses.from(organizationMemberRepository.findByMemberId(memberId));
+	}
+
+	public Organization getOrganizationEntity(Long organizationId) {
+		return organizationRepository.findById(organizationId)
+				.orElseThrow(() -> new NotFoundException(BusinessErrorCode.NOT_FOUND));
 	}
 }

--- a/src/main/java/com/notitime/noffice/domain/announcement/model/Announcement.java
+++ b/src/main/java/com/notitime/noffice/domain/announcement/model/Announcement.java
@@ -9,6 +9,8 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -19,20 +21,19 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder(access = AccessLevel.PRIVATE)
 @Getter
 public class Announcement extends BaseTimeEntity {
 
 	public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
 	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	private String title;
@@ -53,11 +54,9 @@ public class Announcement extends BaseTimeEntity {
 
 	private LocalDateTime endAt;
 
-	@Builder.Default
 	@OneToMany(mappedBy = "announcement", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Task> tasks = new ArrayList<>();
 
-	@Builder.Default
 	@OneToMany(mappedBy = "announcement", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Notification> notifications = new ArrayList<>();
 
@@ -68,18 +67,26 @@ public class Announcement extends BaseTimeEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "organization_id")
 	private Organization organization;
+	
+	public static Announcement createAnnouncement(String title, String content, LocalDateTime endAt, Member member,
+	                                              Organization organizaion) {
+		return new Announcement(null, title, content, null, false, null, null, endAt,
+				new ArrayList<>(), new ArrayList<>(), member, organizaion);
+	}
 
-	public static Announcement createAnnouncement(String title, String content, String profileImageUrl,
-	                                              boolean isFaceToFace,
-	                                              String placeLinkName, String placeLinkUrl, LocalDateTime endAt) {
-		return Announcement.builder()
-				.title(title)
-				.content(content)
-				.profileImageUrl(profileImageUrl)
-				.isFaceToFace(isFaceToFace)
-				.placeLinkName(placeLinkName)
-				.placeLinkUrl(placeLinkUrl)
-				.endAt(endAt)
-				.build();
+	public void withProfileImageUrl(String profileImageUrl) {
+		this.profileImageUrl = profileImageUrl;
+	}
+
+	public void withIsFaceToFace(Boolean isFaceToFace) {
+		this.isFaceToFace = isFaceToFace != null ? isFaceToFace : this.isFaceToFace;
+	}
+
+	public void withPlaceLinkName(String placeLinkName) {
+		this.placeLinkName = placeLinkName;
+	}
+
+	public void withPlaceLinkUrl(String placeLinkUrl) {
+		this.placeLinkUrl = placeLinkUrl;
 	}
 }


### PR DESCRIPTION
## 🚀 Related Issue

close: #53 

## 📌 Tasks

- 공지 생성 관련 정적 팩토리 메소드 구현

## 📝 Details

- business layer에서 객체 탐색하러 가는 find query method와 toResponse mapper method 분리

## 📚 Remarks

- query method는 service에서 가질 수 있지만, 객체 간 매핑, 여러 객체를 묶어서 탐색 등은 별도의 책임을 부여할 수 있음.
- EntityService 클래스에서는 명시된 데이터 형식으로 원하는 쿼리를 수행하는 책임만 부여하도록 개선할 수 있는 여지가 있음.