### PR TITLE
✨ [Feat] 조직별 투두 조회 기능 구현

### DIFF
--- a/src/main/java/com/notitime/noffice/api/task/business/TaskService.java
+++ b/src/main/java/com/notitime/noffice/api/task/business/TaskService.java
@@ -1,6 +1,16 @@
 package com.notitime.noffice.api.task.business;
 
+import com.notitime.noffice.domain.organization.model.Organization;
+import com.notitime.noffice.domain.organization.persistence.OrganizationMemberRepository;
+import com.notitime.noffice.domain.task.model.TaskStatus;
+import com.notitime.noffice.domain.task.persistence.TaskStatusRepository;
+import com.notitime.noffice.response.AssignedTaskResponse;
+import com.notitime.noffice.response.TaskResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -8,4 +18,28 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class TaskService {
+
+	private final TaskStatusRepository taskStatusRepository;
+	private final OrganizationMemberRepository organizationMemberRepository;
+
+	public Slice<AssignedTaskResponse> getAssignedTasks(Long memberId, Pageable pageable) {
+		Slice<Organization> organizations = getSlicedOrganizations(memberId, pageable);
+		List<AssignedTaskResponse> responses = organizations.stream()
+				.map(organization -> searchAssignedTasks(memberId, organization))
+				.toList();
+		return new PageImpl<>(responses, pageable, organizations.getSize());
+	}
+
+	private Slice<Organization> getSlicedOrganizations(Long memberId, Pageable pageable) {
+		return organizationMemberRepository.findOrganizationsByMemberId(memberId, pageable);
+	}
+
+	private AssignedTaskResponse searchAssignedTasks(Long memberId, Organization organization) {
+		List<TaskResponse> tasks = TaskResponse.fromTaskStatus(getTaskStatuses(memberId, organization.getId()));
+		return new AssignedTaskResponse(organization.getId(), organization.getName(), tasks);
+	}
+
+	private List<TaskStatus> getTaskStatuses(Long memberId, Long organizationId) {
+		return taskStatusRepository.findTop5ByOrganizationIdAndMemberId(organizationId, memberId);
+	}
 }

--- a/src/main/java/com/notitime/noffice/api/task/presentation/TaskApi.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/TaskApi.java
@@ -1,17 +1,19 @@
 package com.notitime.noffice.api.task.presentation;
 
+import com.notitime.noffice.auth.LoginUser;
 import com.notitime.noffice.global.response.NofficeResponse;
 import com.notitime.noffice.request.TaskBulkCreateRequest;
 import com.notitime.noffice.request.TaskCreateRequest;
+import com.notitime.noffice.response.AssignedTaskResponse;
 import com.notitime.noffice.response.TaskCreateResponse;
 import com.notitime.noffice.response.TaskCreateResponses;
 import com.notitime.noffice.response.TaskResponses;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "투두", description = "노티/사용자 투두 관련 API")
 interface TaskApi {
@@ -31,20 +33,17 @@ interface TaskApi {
 			@ApiResponse(responseCode = "NOF-2150", description = "투두 대량 생성 성공"),
 			@ApiResponse(responseCode = "NOF-400", description = "투두 대량 생성 실패")
 	})
-	@PostMapping("/bulk")
 	NofficeResponse<TaskCreateResponses> createBulkTask(TaskBulkCreateRequest taskBulkCreateRequest);
-
-	@Operation(summary = "미완료 투두만 조회", responses = {
-			@ApiResponse(responseCode = "NOF-2051", description = "미완료 투두 목록 조회 성공"),
-			@ApiResponse(responseCode = "NOF-404", description = "미완료 투두가 없습니다.")
-	})
-	@GetMapping("/uncompleted")
-	NofficeResponse<TaskResponses> getUncompletedTasks();
 
 	@Operation(summary = "투두 삭제", responses = {
 			@ApiResponse(responseCode = "NOF-2150", description = "투두 삭제 성공"),
 			@ApiResponse(responseCode = "NOF-400", description = "투두 삭제 실패")
 	})
-	@DeleteMapping("/{taskId}")
-	NofficeResponse<Void> deleteTask(Long taskId);
+	NofficeResponse<Void> deleteTask(@PathVariable Long taskId);
+
+	@Operation(summary = "사용자 할당 투두 목록 조회", responses = {
+			@ApiResponse(responseCode = "NOF-2051", description = "사용자 할당 투두 조회 성공"),
+			@ApiResponse(responseCode = "NOF-404", description = "사용자 할당된 투두가 없습니다.")
+	})
+	NofficeResponse<Slice<AssignedTaskResponse>> getAssignedTasks(@LoginUser Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/notitime/noffice/api/task/presentation/TaskController.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/TaskController.java
@@ -1,13 +1,18 @@
 package com.notitime.noffice.api.task.presentation;
 
+import com.notitime.noffice.api.task.business.TaskService;
+import com.notitime.noffice.auth.LoginUser;
 import com.notitime.noffice.global.response.BusinessSuccessCode;
 import com.notitime.noffice.global.response.NofficeResponse;
 import com.notitime.noffice.request.TaskBulkCreateRequest;
 import com.notitime.noffice.request.TaskCreateRequest;
+import com.notitime.noffice.response.AssignedTaskResponse;
 import com.notitime.noffice.response.TaskCreateResponse;
 import com.notitime.noffice.response.TaskCreateResponses;
 import com.notitime.noffice.response.TaskResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +24,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/tasks")
 @RequiredArgsConstructor
 public class TaskController implements TaskApi {
+
+	private final TaskService taskService;
 
 	@GetMapping
 	public NofficeResponse<TaskResponses> getTasks() {
@@ -37,13 +44,14 @@ public class TaskController implements TaskApi {
 
 	}
 
-	@GetMapping("/uncompleted")
-	public NofficeResponse<TaskResponses> getUncompletedTasks() {
-		return NofficeResponse.success(BusinessSuccessCode.OK);
-	}
-
 	@DeleteMapping("/{taskId}")
 	public NofficeResponse<Void> deleteTask(Long taskId) {
 		return NofficeResponse.success(BusinessSuccessCode.OK);
+	}
+
+	@GetMapping("/assigned")
+	public NofficeResponse<Slice<AssignedTaskResponse>> getAssignedTasks(@LoginUser Long memberId, Pageable pageable) {
+		return NofficeResponse.success(BusinessSuccessCode.GET_ASSIGNED_TASKS_SUCCESS,
+				taskService.getAssignedTasks(memberId, pageable));
 	}
 }

--- a/src/main/java/com/notitime/noffice/domain/organization/persistence/OrganizationMemberRepository.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/persistence/OrganizationMemberRepository.java
@@ -1,9 +1,17 @@
 package com.notitime.noffice.domain.organization.persistence;
 
+import com.notitime.noffice.domain.organization.model.Organization;
 import com.notitime.noffice.domain.organization.model.OrganizationMember;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OrganizationMemberRepository extends JpaRepository<OrganizationMember, Long> {
 	List<OrganizationMember> findByMemberId(Long memberId);
+
+	@Query("SELECT om.organization FROM OrganizationMember om WHERE om.member.id = :memberId")
+	Slice<Organization> findOrganizationsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/notitime/noffice/domain/task/model/Task.java
+++ b/src/main/java/com/notitime/noffice/domain/task/model/Task.java
@@ -1,5 +1,6 @@
 package com.notitime.noffice.domain.task.model;
 
+import com.notitime.noffice.domain.BaseTimeEntity;
 import com.notitime.noffice.domain.announcement.model.Announcement;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Task {
+public class Task extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/notitime/noffice/domain/task/persistence/TaskStatusRepository.java
+++ b/src/main/java/com/notitime/noffice/domain/task/persistence/TaskStatusRepository.java
@@ -1,0 +1,16 @@
+package com.notitime.noffice.domain.task.persistence;
+
+import com.notitime.noffice.domain.task.model.TaskStatus;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface TaskStatusRepository extends JpaRepository<TaskStatus, Long> {
+	@Query("SELECT ts FROM TaskStatus ts " +
+			"JOIN FETCH ts.task t " +
+			"WHERE ts.member.id = :memberId " +
+			"AND ts.isChecked = false " +
+			"AND t.announcement.organization.id = :organizationId " +
+			"ORDER BY t.createdAt DESC")
+	List<TaskStatus> findTop5ByOrganizationIdAndMemberId(Long organizationId, Long memberId);
+}

--- a/src/main/java/com/notitime/noffice/global/response/BusinessSuccessCode.java
+++ b/src/main/java/com/notitime/noffice/global/response/BusinessSuccessCode.java
@@ -20,6 +20,7 @@ public enum BusinessSuccessCode implements SuccessCode {
 	GET_ANNOUNCEMENTS_SUCCESS(HttpStatus.OK, "NOF-2051", "노티 목록 조회에 성공하였습니다."),
 	PUT_ANNOUNCEMENT_SUCCESS(HttpStatus.OK, "NOF-2052", "노티 수정에 성공하였습니다."),
 	CHANGE_SEND_TIME_SUCCESS(HttpStatus.OK, "NOF-2072", "알림 발송 시간 변경 성공"),
+	GET_ASSIGNED_TASKS_SUCCESS(HttpStatus.OK, "NOF-2061", "사용자별 투두 목록 조회 성공"),
 
 	// CREATED (2100 ~ 2199)
 	CREATED(HttpStatus.CREATED, "NOF-210", "리소스가 생성되었습니다. - 201"),

--- a/src/main/java/com/notitime/noffice/response/AssignedTaskResponse.java
+++ b/src/main/java/com/notitime/noffice/response/AssignedTaskResponse.java
@@ -1,0 +1,10 @@
+package com.notitime.noffice.response;
+
+import java.util.List;
+
+public record AssignedTaskResponse(
+		Long organizationId,
+		String organizationName,
+		List<TaskResponse> tasks
+) {
+}

--- a/src/main/java/com/notitime/noffice/response/TaskResponse.java
+++ b/src/main/java/com/notitime/noffice/response/TaskResponse.java
@@ -1,9 +1,22 @@
 package com.notitime.noffice.response;
 
 import com.notitime.noffice.domain.task.model.Task;
+import com.notitime.noffice.domain.task.model.TaskStatus;
+import java.util.List;
 
 public record TaskResponse(Long id, Long announcementId, String content) {
 	public static TaskResponse from(Task task) {
 		return new TaskResponse(task.getId(), task.getAnnouncement().getId(), task.getContent());
+	}
+
+	public static TaskResponse from(TaskStatus taskStatus) {
+		Task task = taskStatus.getTask();
+		return new TaskResponse(task.getId(), task.getAnnouncement().getId(), task.getContent());
+	}
+
+	public static List<TaskResponse> fromTaskStatus(List<TaskStatus> taskStatuses) {
+		return taskStatuses.stream()
+				.map(TaskResponse::from)
+				.toList();
 	}
 }


### PR DESCRIPTION
## 🚀 Related Issue

close: #55 

## 📌 Tasks

- 조직별 투두 조회 기능 구현

## 📝 Details
- 조회 로직 추후 변경 여지 존재 (topN 개수 변경, fetch 전략 수정, 캐싱 등에 의함)
```java
	@Query("SELECT ts FROM TaskStatus ts " +
			"JOIN FETCH ts.task t " +
			"WHERE ts.member.id = :memberId " +
			"AND ts.isChecked = false " +
			"AND t.announcement.organization.id = :organizationId " +
			"ORDER BY t.createdAt DESC")
	List<TaskStatus> findTop5ByOrganizationIdAndMemberId(Long organizationId, Long memberId);
```

- 조직 정보를 페이징해서 반환하는데, 사용자 당 기대 조직 가입 수가 적으면 non-paging 메소드로 바꿔도 무방할 것으로 보임
```java
	@Query("SELECT om.organization FROM OrganizationMember om WHERE om.member.id = :memberId")
	Slice<Organization> findOrganizationsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
```

## 📚 Remarks