### PR TITLE
📝 [Docs] Swagger-Autogen 문서화 설정

### DIFF
--- a/src/main/java/com/notitime/noffice/api/announcement/presentation/AnnouncementApi.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/presentation/AnnouncementApi.java
@@ -1,17 +1,16 @@
 package com.notitime.noffice.api.announcement.presentation;
 
-import com.notitime.noffice.auth.LoginUser;
 import com.notitime.noffice.global.response.NofficeResponse;
 import com.notitime.noffice.request.AnnouncementCreateRequest;
 import com.notitime.noffice.request.AnnouncementUpdateRequest;
-import com.notitime.noffice.response.AnnouncementCoverResponse;
 import com.notitime.noffice.response.AnnouncementResponse;
 import com.notitime.noffice.response.AnnouncementResponses;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -19,42 +18,36 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "노티", description = "노티(조직 내 공지) 관련 API")
 public interface AnnouncementApi {
 
-	@Operation(summary = "모든 노티 조회", description = "사용자에게 할당된 모든 노티를 조회합니다.", responses = {
-			@ApiResponse(responseCode = "NOF-2051", description = "노티 목록 조회 성공"),
-			@ApiResponse(responseCode = "NOF-404", description = "등록된 노티가 없습니다.")})
+	@Hidden
+	@Operation(summary = "미사용 - 사용자에게 할당된 모든 노티 조회", description = "사용자에게 할당된 모든 노티를 조회합니다.", responses = {
+			@ApiResponse(responseCode = "200", description = "노티 목록 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "404", description = "등록된 노티가 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
+	})
 	NofficeResponse<AnnouncementResponses> getAnnouncements();
 
 	@Operation(summary = "노티 생성", description = "노티를 생성합니다.", responses = {
-			@ApiResponse(responseCode = "NOF-2150", description = "노티 생성 성공"),
-			@ApiResponse(responseCode = "NOF-400", description = "노티 생성 실패")})
+			@ApiResponse(responseCode = "201", description = "노티 생성 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "400", description = "노티 생성 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
+	})
 	NofficeResponse<AnnouncementResponse> createAnnouncement(
 			@RequestBody final AnnouncementCreateRequest announcementCreateRequest);
 
 	@Operation(summary = "노티 조회", description = "노티를 조회합니다.", responses = {
-			@ApiResponse(responseCode = "NOF-2050", description = "노티 단일 조회 성공"),
-			@ApiResponse(responseCode = "NOF-404", description = "해당 노티가 없습니다.")})
+			@ApiResponse(responseCode = "200", description = "노티 단일 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "404", description = "해당 노티가 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
+	})
 	NofficeResponse<AnnouncementResponse> getAnnouncement(@PathVariable final Long announcementId);
 
 	@Operation(summary = "노티 수정", description = "노티를 수정합니다.", responses = {
-			@ApiResponse(responseCode = "NOF-2052", description = "노티 수정 성공"),
-			@ApiResponse(responseCode = "NOF-404", description = "해당 노티가 없습니다.")})
+			@ApiResponse(responseCode = "200", description = "노티 수정 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "404", description = "해당 노티가 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
+	})
 	NofficeResponse<AnnouncementResponse> updateAnnouncement(@PathVariable final Long announcementId,
 	                                                         @RequestBody final AnnouncementUpdateRequest announcementUpdateRequest);
 
 	@Operation(summary = "노티 삭제", description = "노티를 삭제합니다.", responses = {
-			@ApiResponse(responseCode = "NOF-2053", description = "노티 삭제 성공"),
-			@ApiResponse(responseCode = "NOF-404", description = "노티 삭제에 실패하였습니다.")})
+			@ApiResponse(responseCode = "204", description = "노티 삭제 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "400", description = "노티 삭제에 실패하였습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
+	})
 	NofficeResponse<Void> deleteAnnouncement(@PathVariable final Long announcementId);
-
-	@Operation(summary = "노티에 발행된 알림 개수 조회", description = "노티에 발행된 알림 개수를 조회합니다.", responses = {
-			@ApiResponse(responseCode = "NOF-2072", description = "알림 개수 조회 성공"),
-			@ApiResponse(responseCode = "NOF-404", description = "노티에 발행된 알림이 없습니다.")})
-	NofficeResponse<Integer> getNotificationCount(@PathVariable final Long announcementId);
-
-	@Operation(summary = "조직별 노티 페이징 조회", description = "조직별 노티를 페이징 조회합니다.", responses = {
-			@ApiResponse(responseCode = "NOF-2073", description = "조직별 노티 페이징 조회 성공"),
-			@ApiResponse(responseCode = "NOF-404", description = "조직에 등록된 노티가 없습니다.")})
-	NofficeResponse<Slice<AnnouncementCoverResponse>> getPublishedAnnouncements(@LoginUser final Long memberId,
-	                                                                            @PathVariable final Long organizationId,
-	                                                                            Pageable pageable);
 }

--- a/src/main/java/com/notitime/noffice/api/member/presentation/MemberApi.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/MemberApi.java
@@ -6,6 +6,8 @@ import com.notitime.noffice.response.MemberResponse;
 import com.notitime.noffice.response.SocialAuthResponse;
 import com.notitime.noffice.response.TokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,17 +17,17 @@ import org.springframework.web.bind.annotation.RequestHeader;
 @Tag(name = "회원", description = "회원 로그인, 정보 조회 API")
 public interface MemberApi {
 	@Operation(summary = "회원 로그인", description = "본문에 소셜 공급자명과 인가코드를 넣어 노피스 서버 로그인을 시도합니다.", responses = {
-			@ApiResponse(responseCode = "NOF-2000", description = "로그인에 성공하였습니다."),
-			@ApiResponse(responseCode = "NOF-401", description = "로그인에 실패하였습니다. - 유효하지 않은 액세스 토큰입니다.")})
+			@ApiResponse(responseCode = "200", description = "로그인에 성공하였습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
+	})
 	NofficeResponse<SocialAuthResponse> login(@RequestBody final SocialAuthRequest socialLoginRequest);
 
 	@Operation(summary = "토큰 재발급", description = "리프레시 토큰을 이용해 새로운 액세스 토큰을 발급합니다.", responses = {
-			@ApiResponse(responseCode = "NOF-2000", description = "액세스 토큰 재발급에 성공하였습니다."),
-			@ApiResponse(responseCode = "NOF-401", description = "토큰 재발급 실패")})
+			@ApiResponse(responseCode = "200", description = "액세스 토큰 재발급에 성공하였습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
+	})
 	NofficeResponse<TokenResponse> reissue(@RequestHeader("Authorization") final String refreshToken);
 
 	@Operation(summary = "단일 회원 정보 조회", description = "회원의 정보를 조회합니다.", responses = {
-			@ApiResponse(responseCode = "NOF-2001", description = "회원 정보 조회에 성공하였습니다."),
-			@ApiResponse(responseCode = "NOF-404", description = "회원 정보가 없습니다.")})
+			@ApiResponse(responseCode = "200", description = "회원 정보 조회에 성공하였습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
+	})
 	NofficeResponse<MemberResponse> getMember(@PathVariable final Long memberId);
 }

--- a/src/main/java/com/notitime/noffice/api/notification/presentation/NotificationApi.java
+++ b/src/main/java/com/notitime/noffice/api/notification/presentation/NotificationApi.java
@@ -6,52 +6,45 @@ import com.notitime.noffice.request.NotificationTimeChangeRequest;
 import com.notitime.noffice.response.NotificationBulkRequest;
 import com.notitime.noffice.response.NotificationTimeChangeResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "알림", description = "노티 알림 발송 관련 API")
-@RequestMapping("/api/v1/notifications")
 interface NotificationApi {
 
 	@Operation(summary = "단일 사용자 알림 대기열 추가", description = "단일 사용자를 특정하여 노티 알림 대기열에 등록합니다.", responses = {
-			@ApiResponse(responseCode = "NOF-20710", description = "알림 대기열 등록 성공"),
-			@ApiResponse(responseCode = "NOF-400", description = "알림 발송 실패")})
-	@PostMapping
+			@ApiResponse(responseCode = "200", description = "알림 대기열 등록 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "400", description = "알림 발송 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
+	})
 	NofficeResponse<Void> createNotification(@RequestBody final NotificationRequest request);
 
 	@Operation(summary = "조직 단위 알림 대량 발송", description = "조직 내 모든 사용자에게 전체 발송되는 알림을 등록합니다.", responses = {
-			@ApiResponse(responseCode = "NOF-20711", description = "조직 전체 알림 대량 등록 성공"),
-			@ApiResponse(responseCode = "NOF-400", description = "조직 전체 알림 대량 등록 실패")})
-	@PostMapping("/bulk")
+			@ApiResponse(responseCode = "200", description = "조직 전체 알림 대량 등록 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "400", description = "조직 전체 알림 대량 등록 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
+	})
 	NofficeResponse<Void> createBulkNotification(@RequestBody final NotificationBulkRequest request);
 
 	@Operation(summary = "사용자에게 수신된 알림 조회", description = "사용자에게 수신된 알림을 조회합니다.", responses = {
-			@ApiResponse(responseCode = "NOF-2071", description = "알림 조회 성공"),
-			@ApiResponse(responseCode = "NOF-404", description = "알림이 없습니다.")
+			@ApiResponse(responseCode = "200", description = "알림 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "404", description = "알림이 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
 	})
-	@GetMapping
 	NofficeResponse<Void> getNotifications(@RequestParam final Long memberId);
 
 	@Operation(summary = "알림 발송 시간 변경", description = "노티 알림 발송 시간을 변경합니다.", responses = {
-			@ApiResponse(responseCode = "NOF-2072", description = "알림 발송 시간 변경 성공"),
-			@ApiResponse(responseCode = "NOF-400", description = "알림 발송 시간 변경 실패")
+			@ApiResponse(responseCode = "200", description = "알림 발송 시간 변경 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "400", description = "알림 발송 시간 변경 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
 	})
-	@PatchMapping
 	NofficeResponse<NotificationTimeChangeResponse> changeSendTime(
 			@RequestBody final NotificationTimeChangeRequest request);
 
 	@Operation(summary = "알림 삭제", description = "노티 알림을 삭제합니다.", responses = {
-			@ApiResponse(responseCode = "NOF-2073", description = "알림 삭제 성공"),
-			@ApiResponse(responseCode = "NOF-400", description = "알림 삭제 실패")
+			@ApiResponse(responseCode = "204", description = "알림 삭제 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "400", description = "알림 삭제 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
 	})
-	@DeleteMapping("/{notificationId}")
 	NofficeResponse<Void> deleteNotification(@PathVariable final Long notificationId);
 }

--- a/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationApi.java
+++ b/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationApi.java
@@ -3,9 +3,12 @@ package com.notitime.noffice.api.organization.presentation;
 import com.notitime.noffice.auth.LoginUser;
 import com.notitime.noffice.global.response.NofficeResponse;
 import com.notitime.noffice.request.OrganizationCreateRequest;
+import com.notitime.noffice.response.AnnouncementCoverResponse;
 import com.notitime.noffice.response.OrganizationJoinResponse;
 import com.notitime.noffice.response.OrganizationResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -17,24 +20,37 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "조직", description = "조직 관련 API")
 public interface OrganizationApi {
 
-	@Operation(summary = "사용자의 가입된 조직 페이징 조회", description = "멤버가 가입한 조직 목록을 조회합니다.", responses = {
-			@ApiResponse(responseCode = "NOF-2002", description = "회원의 가입된 조직 조회에 성공하였습니다."),
-			@ApiResponse(responseCode = "NOF-404", description = "가입된 조직이 없습니다.")})
-	NofficeResponse<Slice<OrganizationResponse>> getJoinedOrganizations(@LoginUser Long memberId,
-	                                                                    Pageable pageable);
-
 	@Operation(summary = "단일 조직 정보 조회", description = "조직의 정보를 조회합니다.", responses = {
-			@ApiResponse(responseCode = "NOF-2003", description = "조직 정보 조회에 성공하였습니다."),
-			@ApiResponse(responseCode = "NOF-404", description = "조직 정보가 없습니다.")})
+			@ApiResponse(responseCode = "200", description = "조직 정보 조회에 성공하였습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "404", description = "조직 정보가 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
+	})
 	NofficeResponse<OrganizationResponse> getOrganization(@PathVariable Long organizationId);
 
 	@Operation(summary = "조직 생성", description = "조직을 생성합니다.", responses = {
-			@ApiResponse(responseCode = "NOF-2100", description = "조직 생성에 성공하였습니다.")})
+			@ApiResponse(responseCode = "201", description = "조직 생성에 성공하였습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "400", description = "조직 생성에 실패하였습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
+	})
 	NofficeResponse<OrganizationResponse> createOrganization(@LoginUser Long memberId,
 	                                                         @RequestBody @Valid final OrganizationCreateRequest request);
 
 	@Operation(summary = "조직 가입", description = "조직에 가입합니다.", responses = {
-			@ApiResponse(responseCode = "NOF-2101", description = "조직 가입에 성공하였습니다.")})
+			@ApiResponse(responseCode = "200", description = "조직 가입에 성공하였습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
+	})
 	NofficeResponse<OrganizationJoinResponse> joinOrganization(@LoginUser Long memberId,
 	                                                           @PathVariable Long organizationId);
+
+	@Operation(summary = "사용자의 가입된 조직 페이징 조회", description = "멤버가 가입한 조직 목록을 조회합니다.", responses = {
+			@ApiResponse(responseCode = "200", description = "회원의 가입된 조직 조회에 성공하였습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "404", description = "가입된 조직이 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
+	})
+	NofficeResponse<Slice<OrganizationResponse>> getJoinedOrganizations(@LoginUser Long memberId,
+	                                                                    Pageable pageable);
+
+	@Operation(summary = "조직별 노티 페이징 조회", description = "조직별 노티를 페이징 조회합니다.", responses = {
+			@ApiResponse(responseCode = "200", description = "조직별 노티 페이징 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "404", description = "조직에 등록된 노티가 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
+	})
+	NofficeResponse<Slice<AnnouncementCoverResponse>> getPublishedAnnouncements(@LoginUser final Long memberId,
+	                                                                            @PathVariable final Long organizationId,
+	                                                                            Pageable pageable);
 }

--- a/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationController.java
+++ b/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationController.java
@@ -1,10 +1,12 @@
 package com.notitime.noffice.api.organization.presentation;
 
+import com.notitime.noffice.api.announcement.business.AnnouncementService;
 import com.notitime.noffice.api.organization.business.OrganizationService;
 import com.notitime.noffice.auth.LoginUser;
 import com.notitime.noffice.global.response.BusinessSuccessCode;
 import com.notitime.noffice.global.response.NofficeResponse;
 import com.notitime.noffice.request.OrganizationCreateRequest;
+import com.notitime.noffice.response.AnnouncementCoverResponse;
 import com.notitime.noffice.response.OrganizationJoinResponse;
 import com.notitime.noffice.response.OrganizationResponse;
 import jakarta.validation.Valid;
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrganizationController implements OrganizationApi {
 
 	private final OrganizationService organizationService;
+	private final AnnouncementService announcementService;
 
 	@GetMapping
 	public NofficeResponse<Slice<OrganizationResponse>> getJoinedOrganizations(@LoginUser final Long memberId,
@@ -47,5 +50,12 @@ public class OrganizationController implements OrganizationApi {
 	public NofficeResponse<OrganizationJoinResponse> joinOrganization(@LoginUser final Long memberId,
 	                                                                  @PathVariable Long organizationId) {
 		return NofficeResponse.success(BusinessSuccessCode.POST_JOIN_ORGANIZATION_SUCCESS);
+	}
+
+	@GetMapping("/{organizationId}/announcements")
+	public NofficeResponse<Slice<AnnouncementCoverResponse>> getPublishedAnnouncements(
+			@LoginUser final Long memberId, @PathVariable final Long organizationId, Pageable pageable) {
+		return NofficeResponse.success(BusinessSuccessCode.GET_PUBLISHED_ANNOUNCEMENTS_SUCCESS,
+				announcementService.getPublishedAnnouncements(organizationId, pageable));
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/task/presentation/TaskApi.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/TaskApi.java
@@ -9,41 +9,43 @@ import com.notitime.noffice.response.TaskCreateResponse;
 import com.notitime.noffice.response.TaskCreateResponses;
 import com.notitime.noffice.response.TaskResponses;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@Tag(name = "투두", description = "노티/사용자 투두 관련 API")
+@Tag(name = "투두", description = "노티 하위 발급 투두 리스트 관련 API")
 interface TaskApi {
 	@Operation(summary = "투두 목록 조회", responses = {
-			@ApiResponse(responseCode = "NOF-2051", description = "투두 목록 조회 성공"),
-			@ApiResponse(responseCode = "NOF-404", description = "등록된 투두가 없습니다.")
+			@ApiResponse(responseCode = "200", description = "투두 목록 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "404", description = "등록된 투두가 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
 	})
 	NofficeResponse<TaskResponses> getTasks();
 
 	@Operation(summary = "투두 생성", responses = {
-			@ApiResponse(responseCode = "NOF-2150", description = "투두 생성 성공"),
-			@ApiResponse(responseCode = "NOF-400", description = "투두 생성 실패")
+			@ApiResponse(responseCode = "201", description = "투두 생성 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "400", description = "투두 생성 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
 	})
 	NofficeResponse<TaskCreateResponse> createTask(TaskCreateRequest taskCreateRequest);
 
 	@Operation(summary = "투두 대량 생성", responses = {
-			@ApiResponse(responseCode = "NOF-2150", description = "투두 대량 생성 성공"),
-			@ApiResponse(responseCode = "NOF-400", description = "투두 대량 생성 실패")
+			@ApiResponse(responseCode = "201", description = "투두 대량 생성 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "400", description = "투두 대량 생성 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
 	})
 	NofficeResponse<TaskCreateResponses> createBulkTask(TaskBulkCreateRequest taskBulkCreateRequest);
 
 	@Operation(summary = "투두 삭제", responses = {
-			@ApiResponse(responseCode = "NOF-2150", description = "투두 삭제 성공"),
-			@ApiResponse(responseCode = "NOF-400", description = "투두 삭제 실패")
+			@ApiResponse(responseCode = "204", description = "투두 삭제 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "400", description = "투두 삭제 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
 	})
 	NofficeResponse<Void> deleteTask(@PathVariable Long taskId);
 
 	@Operation(summary = "사용자 할당 투두 목록 조회", responses = {
-			@ApiResponse(responseCode = "NOF-2051", description = "사용자 할당 투두 조회 성공"),
-			@ApiResponse(responseCode = "NOF-404", description = "사용자 할당된 투두가 없습니다.")
+			@ApiResponse(responseCode = "200", description = "사용자 할당 투두 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "404", description = "사용자 할당된 투두가 없습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = NofficeResponse.class)))
 	})
 	NofficeResponse<Slice<AssignedTaskResponse>> getAssignedTasks(@LoginUser Long memberId, Pageable pageable);
 }


### PR DESCRIPTION
## 🚀 Related Issue

close: #62 

## 📌 Tasks

- [Swagger ResponseCode 표기법 변경](https://github.com/Team-Notitime/NOFFICE-SERVER/commit/1e8eedc9401373784d845eccc6b721a808e77cfb)

## 📝 Details

- Client project DTO 자동 변환을 위해 [Swagger-autogen](https://swagger-autogen.github.io/)을 사용했는데, `responseCode`에 커스텀 응답코드를 넣어둔 부분에서 `parseException`이 발생했어요.
- `HttpStatusCode`를 기준으로 표기법을 변경했어요.

## 📚 Remarks

- 
- 