### PR TITLE
✨ [Feat] 조직 가입 기능

### DIFF
--- a/src/main/java/com/notitime/noffice/api/OrganizationRoleVerifier.java
+++ b/src/main/java/com/notitime/noffice/api/OrganizationRoleVerifier.java
@@ -1,0 +1,38 @@
+package com.notitime.noffice.api;
+
+import com.notitime.noffice.domain.JoinStatus;
+import com.notitime.noffice.domain.OrganizationRole;
+import com.notitime.noffice.domain.organization.persistence.OrganizationMemberRepository;
+import com.notitime.noffice.global.exception.ForbiddenException;
+import com.notitime.noffice.global.response.BusinessErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrganizationRoleVerifier {
+
+	private final OrganizationMemberRepository organizationMemberRepository;
+
+	public void verifyJoinedMember(Long memberId, Long organizationId) {
+		if (isActiveMember(memberId, organizationId)) {
+			throw new ForbiddenException(BusinessErrorCode.FORBIDDEN_ORGANIZATION_ACCESS);
+		}
+	}
+
+	public void verifyRole(Long memberId, Long organizationId, OrganizationRole role) {
+		if (isActiveMemberWithRole(memberId, organizationId, role)) {
+			throw new ForbiddenException(BusinessErrorCode.FORBIDDEN_ORGANIZATION_ACCESS);
+		}
+	}
+
+	private boolean isActiveMemberWithRole(Long memberId, Long organizationId, OrganizationRole role) {
+		return organizationMemberRepository.existsByMemberIdAndOrganizationIdAndRoleAndStatus(memberId, organizationId,
+				role, JoinStatus.ACTIVE);
+	}
+
+	private boolean isActiveMember(Long memberId, Long organizationId) {
+		return organizationMemberRepository.existsByMemberIdAndOrganizationIdAndStatus(memberId, organizationId,
+				JoinStatus.ACTIVE);
+	}
+}

--- a/src/main/java/com/notitime/noffice/api/member/business/MemberService.java
+++ b/src/main/java/com/notitime/noffice/api/member/business/MemberService.java
@@ -20,7 +20,7 @@ public class MemberService {
 		return MemberResponse.of(getMemberEntity(memberId));
 	}
 
-	public Member getMemberEntity(Long memberId) {
+	private Member getMemberEntity(Long memberId) {
 		return memberRepository.findById(memberId)
 				.orElseThrow(() -> new NotFoundException(BusinessErrorCode.NOT_FOUND));
 	}

--- a/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationController.java
+++ b/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationController.java
@@ -51,7 +51,8 @@ public class OrganizationController implements OrganizationApi {
 	@PostMapping("/{organizationId}/join")
 	public NofficeResponse<OrganizationJoinResponse> joinOrganization(@LoginUser final Long memberId,
 	                                                                  @PathVariable Long organizationId) {
-		return NofficeResponse.success(BusinessSuccessCode.POST_JOIN_ORGANIZATION_SUCCESS);
+		return NofficeResponse.success(BusinessSuccessCode.POST_JOIN_ORGANIZATION_SUCCESS,
+				organizationService.joinOrganization(memberId, organizationId));
 	}
 
 	@GetMapping("/{organizationId}/announcements")

--- a/src/main/java/com/notitime/noffice/domain/JoinStatus.java
+++ b/src/main/java/com/notitime/noffice/domain/JoinStatus.java
@@ -1,0 +1,5 @@
+package com.notitime.noffice.domain;
+
+public enum JoinStatus {
+	ACTIVE, PENDING, REJECTED, DELETED
+}

--- a/src/main/java/com/notitime/noffice/domain/OrganizationRole.java
+++ b/src/main/java/com/notitime/noffice/domain/OrganizationRole.java
@@ -1,5 +1,5 @@
 package com.notitime.noffice.domain;
 
 public enum OrganizationRole {
-	ADMIN, LEADER, PARTICIPANT
+	ADMIN, LEADER, PARTICIPANT, GUEST
 }

--- a/src/main/java/com/notitime/noffice/domain/organization/model/OrganizationMember.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/model/OrganizationMember.java
@@ -1,5 +1,6 @@
 package com.notitime.noffice.domain.organization.model;
 
+import com.notitime.noffice.domain.JoinStatus;
 import com.notitime.noffice.domain.OrganizationRole;
 import com.notitime.noffice.domain.member.model.Member;
 import jakarta.persistence.Entity;
@@ -7,6 +8,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -20,11 +22,14 @@ import lombok.NoArgsConstructor;
 public class OrganizationMember {
 
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	@Enumerated(EnumType.STRING)
 	private OrganizationRole role;
+
+	@Enumerated(EnumType.STRING)
+	private JoinStatus status;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "organization_id")
@@ -33,4 +38,11 @@ public class OrganizationMember {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
 	private Member member;
+
+	public OrganizationMember(Organization organization, Member member) {
+		this.organization = organization;
+		this.member = member;
+		this.role = OrganizationRole.GUEST;
+		this.status = JoinStatus.PENDING;
+	}
 }

--- a/src/main/java/com/notitime/noffice/domain/organization/persistence/OrganizationMemberRepository.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/persistence/OrganizationMemberRepository.java
@@ -1,5 +1,11 @@
 package com.notitime.noffice.domain.organization.persistence;
 
+import static com.notitime.noffice.domain.OrganizationRole.LEADER;
+import static com.notitime.noffice.domain.OrganizationRole.PARTICIPANT;
+
+import com.notitime.noffice.domain.JoinStatus;
+import com.notitime.noffice.domain.OrganizationRole;
+import com.notitime.noffice.domain.member.model.Member;
 import com.notitime.noffice.domain.organization.model.Organization;
 import com.notitime.noffice.domain.organization.model.OrganizationMember;
 import java.util.List;
@@ -14,4 +20,27 @@ public interface OrganizationMemberRepository extends JpaRepository<Organization
 
 	@Query("SELECT om.organization FROM OrganizationMember om WHERE om.member.id = :memberId")
 	Slice<Organization> findOrganizationsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+
+	@Query("SELECT om.member FROM OrganizationMember om WHERE om.organization.id = :organizationId")
+	Slice<Member> findMembersByOrganizationId(@Param("organizationId") Long organizationId, Pageable pageable);
+
+	@Query("SELECT om.member FROM OrganizationMember om WHERE om.organization.id = :organizationId AND om.role = :role")
+	List<Member> findMembersByOrganizationIdAndRole(@Param("organizationId") Long organizationId,
+	                                                @Param("role") OrganizationRole role);
+
+	default List<Member> findLeadersByOrganizationId(Long organizationId) {
+		return findMembersByOrganizationIdAndRole(organizationId, LEADER);
+	}
+
+	default List<Member> findParticipantsByOrganizationId(Long organizationId) {
+		return findMembersByOrganizationIdAndRole(organizationId, PARTICIPANT);
+	}
+
+	boolean existsByMemberIdAndOrganizationIdAndRole(Long memberId, Long organizationId,
+	                                                 OrganizationRole organizationRole);
+
+	boolean existsByMemberIdAndOrganizationIdAndStatus(Long memberId, Long organizationId, JoinStatus status);
+
+	boolean existsByMemberIdAndOrganizationIdAndRoleAndStatus(Long memberId, Long organizationId, OrganizationRole role,
+	                                                          JoinStatus status);
 }

--- a/src/main/java/com/notitime/noffice/global/exception/ForbiddenException.java
+++ b/src/main/java/com/notitime/noffice/global/exception/ForbiddenException.java
@@ -1,0 +1,17 @@
+package com.notitime.noffice.global.exception;
+
+import com.notitime.noffice.global.response.BusinessErrorCode;
+
+public class ForbiddenException extends NofficeException {
+	public ForbiddenException(String message, BusinessErrorCode errorCode) {
+		super(message, errorCode);
+	}
+
+	public ForbiddenException(String message) {
+		super(message, BusinessErrorCode.FORBIDDEN);
+	}
+
+	public ForbiddenException(BusinessErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/notitime/noffice/global/response/BusinessErrorCode.java
+++ b/src/main/java/com/notitime/noffice/global/response/BusinessErrorCode.java
@@ -11,7 +11,6 @@ public enum BusinessErrorCode implements ErrorCode {
 	// 400 Bad Request
 	BAD_REQUEST(HttpStatus.BAD_REQUEST, "NOF-400", "잘못된 요청입니다."),
 	FAILED_TO_LOAD_PRIVATE_KEY(HttpStatus.BAD_REQUEST, "NOF-400", "개인 키를 로드하는 데 실패했습니다."),
-	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "NOF-500", "서버 내부 오류가 발생했습니다."),
 	INVALID_APPLE_IDENTITY_TOKEN(HttpStatus.UNAUTHORIZED, "NOF-401", "유효하지 않은 아이덴티티 토큰입니다."),
 	UNSUPPORTED_ALGORITHM(HttpStatus.BAD_REQUEST, "NOF-400", "키 생성에 사용된 알고리즘을 지원하지 않습니다: "),
 	INVALID_KEY_SPEC(HttpStatus.BAD_REQUEST, "NOF-400", "공개 키 생성에 잘못된 키 사양이 제공되었습니다."),
@@ -33,11 +32,18 @@ public enum BusinessErrorCode implements ErrorCode {
 
 	// 403 Forbidden
 	FORBIDDEN(HttpStatus.FORBIDDEN, "NOF-403", "리소스에 대한 접근 권한이 없습니다."),
+	FORBIDDEN_ORGANIZATION_ACCESS(HttpStatus.FORBIDDEN, "NOF-403", "조직에 대한 접근 권한이 없습니다."),
 
 	// 404 Not Found
 	NOT_FOUND(HttpStatus.NOT_FOUND, "NOF-404", "리소스를 찾을 수 없습니다."),
 	NOT_FOUND_ANNOUNCEMENT(HttpStatus.NOT_FOUND, "NOF-4450", "공지사항을 찾을 수 없습니다."),
-	STORE_FILE_SIZE_EXCEEDED(HttpStatus.NOT_FOUND, "NOF-404", "업로드 가능한 파일 크기를 초과했습니다.");
+	NOT_FOUND_TASK(HttpStatus.NOT_FOUND, "NOF-4460", "요청한 투두를 찾을 수 없습니다."),
+	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "NOF-4470", "멤버를 찾을 수 없습니다."),
+	NOT_FOUND_ORGANIZATION(HttpStatus.NOT_FOUND, "NOF-4480", "조직을 찾을 수 없습니다."),
+	STORE_FILE_SIZE_EXCEEDED(HttpStatus.NOT_FOUND, "NOF-404", "업로드 가능한 파일 크기를 초과했습니다."),
+
+	// 500 Internal Server Error
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "NOF-500", "서버 내부 오류가 발생했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/notitime/noffice/response/OrganizationJoinResponse.java
+++ b/src/main/java/com/notitime/noffice/response/OrganizationJoinResponse.java
@@ -1,4 +1,19 @@
 package com.notitime.noffice.response;
 
-public record OrganizationJoinResponse(Long id, String name, String link) {
+import com.notitime.noffice.domain.member.model.Member;
+import com.notitime.noffice.domain.organization.model.Organization;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+
+public record OrganizationJoinResponse(
+		@Schema(requiredMode = RequiredMode.REQUIRED, description = "조직 ID", example = "1")
+		Long organizationId,
+		@Schema(requiredMode = RequiredMode.NOT_REQUIRED, description = "조직 이름", example = "Noffice")
+		String organizationName,
+		@Schema(requiredMode = RequiredMode.REQUIRED, description = "가입한 사용자 식별자", example = "1")
+		Long userId) {
+
+	public static OrganizationJoinResponse from(Organization organization, Member member) {
+		return new OrganizationJoinResponse(organization.getId(), organization.getName(), member.getId());
+	}
 }


### PR DESCRIPTION
## 🚀 Related Issue

close: #66 

## 📌 Tasks

- 조직 가입 신청 기능
 - 초기 가입신청 시 `JoinStatus == PENDING, Role == GUEST` 상태로 가입

## 📝 Details

- 이미 가입이 완료된 식별자의 가입 신청 방지를 위한 `OrganizationRoleVerifier` service 클래스 추가
- 특정 조직 내 역할, 가입 상태 단위로 조직 내 사용자를 탐색하는 QueryMethod 추가

## 📚 Remarks

- 도메인 간 서비스 레이어에서 엔티티 탐색 메소드를 상호 의존하는 구조를 변경
 - 각 서비스 레이어는 엔티티 탐색을 위해 persistence layer를 의존
 - 해당 기능 구현과 직접적 관계는 없으나, 서비스 간 접근을 캡슐화하여 방지하기 위함
- 