### PR TITLE
✨ [Feat] 그룹 대표 이미지 S3 업로드 및 조회 기능

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -23,6 +23,10 @@ jobs:
       GOOGLE_REDIRECT_URI: ${{secrets.GOOGLE_REDIRECT_URI}}
       SERVER_DOMAIN_ORIGIN: ${{secrets.SERVER_DOMAIN_ORIGIN}}
       SERVER_DOMAIN_CERTIFIED: ${{secrets.SERVER_DOMAIN_CERTIFIED}}
+      AWS_ACCESS_KEY: ${{secrets.AWS_ACCESS_KEY}}
+      AWS_SECRET_KEY: ${{secrets.AWS_SECRET_KEY}}
+      AWS_REGION: ${{secrets.AWS_REGION}}
+      AWS_S3_BUCKET_NAME: ${{secrets.AWS_S3_BUCKET_NAME}}
 
 
     steps:

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 
     // OpenFeign
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
-    
+
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
@@ -60,6 +60,10 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // AWS
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4'
 }
 
 tasks.named('test') {

--- a/docs/NOFFICE-erd.md
+++ b/docs/NOFFICE-erd.md
@@ -120,6 +120,13 @@ erDiagram
         bigint announcement_id FK
         timestamp send_at
     }
+    
+    CONTENT_IMAGE {
+        bigint id PK
+        varchar title
+        ImagePurpose imagePurpose
+        text image_url
+    }
 
     BASETIMEENTITY {
         timestamp created_at

--- a/src/main/java/com/notitime/noffice/api/image/business/ContentImageService.java
+++ b/src/main/java/com/notitime/noffice/api/image/business/ContentImageService.java
@@ -1,0 +1,89 @@
+package com.notitime.noffice.api.image.business;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.notitime.noffice.api.image.business.dto.ImagePurpose;
+import com.notitime.noffice.domain.image.model.ContentImage;
+import com.notitime.noffice.domain.image.persistence.ContentImageRepository;
+import java.net.URL;
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class ContentImageService {
+
+	@Value("${aws.s3-bucket-name}")
+	private String bucket;
+
+	private final AmazonS3 s3Client;
+	private final ContentImageRepository contentImageRepository;
+
+	public Map<String, String> getPresignedUrl(String fileType, String fileName, ImagePurpose imagePurpose) {
+		if (!fileType.isEmpty()) {
+			fileName = createPath(fileType, fileName, imagePurpose);
+		}
+
+		GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePresignedUrlRequest(bucket, fileName);
+		URL url = s3Client.generatePresignedUrl(generatePresignedUrlRequest);
+
+		ContentImage contentImage = new ContentImage(fileName, url.toString(), imagePurpose);
+		contentImageRepository.save(contentImage);
+
+		return Map.of("url", url.toString());
+	}
+
+	private GeneratePresignedUrlRequest getGeneratePresignedUrlRequest(String bucket, String fileName) {
+		GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucket, fileName)
+				.withMethod(HttpMethod.PUT)
+				.withExpiration(getPresignedUrlExpiration());
+
+		generatePresignedUrlRequest.addRequestParameter(
+				Headers.S3_CANNED_ACL,
+				CannedAccessControlList.PublicRead.toString()
+		);
+
+		return generatePresignedUrlRequest;
+	}
+
+	private Date getPresignedUrlExpiration() {
+		Date expiration = new Date();
+		long expTimeMillis = expiration.getTime();
+		expTimeMillis += 2000 * 60 * 2;
+		expiration.setTime(expTimeMillis);
+
+		return expiration;
+	}
+
+	private String createFileId() {
+		return UUID.randomUUID().toString();
+	}
+
+	private String createPath(String fileType, String fileName, ImagePurpose imagePurpose) {
+		String fileId = createFileId();
+		String prefixForImagePurpose = getPrefixForImagePurpose(imagePurpose);
+		String prefixForFileType = fileType.toLowerCase();
+		return String.format("%s/%s-%s.%s", prefixForFileType, fileId, fileName,
+				prefixForFileType);
+	}
+
+	private String getPrefixForImagePurpose(ImagePurpose imagePurpose) {
+		return switch (imagePurpose) {
+			case MEMBER_PROFILE -> "member-profile";
+			case ORGANIZATION_LOGO -> "organization-logo";
+			case ANNOUNCEMENT_PROFILE -> "announcement-profile";
+			case ANNOUNCEMENT_CONTENT -> "announcement-content";
+			case PROMOTION_COVER -> "promotion-cover";
+			default -> "default";
+		};
+	}
+}

--- a/src/main/java/com/notitime/noffice/api/image/business/dto/ContentImagePresignedUrlVO.java
+++ b/src/main/java/com/notitime/noffice/api/image/business/dto/ContentImagePresignedUrlVO.java
@@ -1,0 +1,12 @@
+package com.notitime.noffice.api.image.business.dto;
+
+import java.util.Map;
+
+public record ContentImagePresignedUrlVO(
+		String fileName,
+		Map<String, String> urls
+) {
+	public static ContentImagePresignedUrlVO of(String fileName, Map<String, String> urls) {
+		return new ContentImagePresignedUrlVO(fileName, urls);
+	}
+}

--- a/src/main/java/com/notitime/noffice/api/image/business/dto/ContentImageResponse.java
+++ b/src/main/java/com/notitime/noffice/api/image/business/dto/ContentImageResponse.java
@@ -1,0 +1,10 @@
+package com.notitime.noffice.api.image.business.dto;
+
+import com.notitime.noffice.domain.image.model.ContentImage;
+
+public record ContentImageResponse(Long id, String title, String imageUrl) {
+
+	public static ContentImageResponse of(ContentImage contentImage) {
+		return new ContentImageResponse(contentImage.getId(), contentImage.getTitle(), contentImage.getImageUrl());
+	}
+}

--- a/src/main/java/com/notitime/noffice/api/image/business/dto/ContentImageResponses.java
+++ b/src/main/java/com/notitime/noffice/api/image/business/dto/ContentImageResponses.java
@@ -1,0 +1,15 @@
+package com.notitime.noffice.api.image.business.dto;
+
+import com.notitime.noffice.domain.image.model.ContentImage;
+import java.util.List;
+
+public record ContentImageResponses(List<ContentImageResponse> images) {
+	public static ContentImageResponses from(List<ContentImage> images) {
+		List<ContentImageResponse> responses = images.stream()
+				.map(ContentImageResponse::of)
+				.toList();
+
+		return new ContentImageResponses(responses);
+	}
+}
+

--- a/src/main/java/com/notitime/noffice/api/image/business/dto/ImagePurpose.java
+++ b/src/main/java/com/notitime/noffice/api/image/business/dto/ImagePurpose.java
@@ -1,0 +1,9 @@
+package com.notitime.noffice.api.image.business.dto;
+
+public enum ImagePurpose {
+	ORGANIZATION_LOGO,
+	MEMBER_PROFILE,
+	ANNOUNCEMENT_PROFILE,
+	ANNOUNCEMENT_CONTENT,
+	PROMOTION_COVER,
+}

--- a/src/main/java/com/notitime/noffice/api/image/business/dto/NotifyContentImageSaveSuccessRequest.java
+++ b/src/main/java/com/notitime/noffice/api/image/business/dto/NotifyContentImageSaveSuccessRequest.java
@@ -1,0 +1,6 @@
+package com.notitime.noffice.api.image.business.dto;
+
+public record NotifyContentImageSaveSuccessRequest(
+		String fileName
+) {
+}

--- a/src/main/java/com/notitime/noffice/api/image/presentation/ContentImageApi.java
+++ b/src/main/java/com/notitime/noffice/api/image/presentation/ContentImageApi.java
@@ -1,0 +1,27 @@
+package com.notitime.noffice.api.image.presentation;
+
+import com.notitime.noffice.api.image.business.dto.ContentImagePresignedUrlVO;
+import com.notitime.noffice.api.image.business.dto.ImagePurpose;
+import com.notitime.noffice.api.image.business.dto.NotifyContentImageSaveSuccessRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "이미지", description = "이미지 업로드 및 디렉토리 요청 API")
+public interface ContentImageApi {
+	@Operation(summary = "컨텐츠 이미지 업로드 위치 요청", description = "fileType에는 확장자를, fileName은 파일명을 넣어주세요. imageType은 이미지 유형을 명시해주세요.", responses = {
+			@ApiResponse(responseCode = "200", description = "이미지 업로드 위치 요청에 성공하였습니다.")
+	})
+	ResponseEntity<ContentImagePresignedUrlVO> getContentImage(@RequestParam final String fileType,
+	                                                           @RequestParam final String fileName,
+	                                                           @RequestParam final ImagePurpose imagePurpose
+	);
+
+	@Operation(summary = "컨텐츠 이미지 업로드 완료", description = "컨텐츠 이미지 업로드 완료를 노피스 서버에 알립니다.", responses = {
+			@ApiResponse(responseCode = "200", description = "별도 파일을 제외한 POST 요청을 발송해주세요.")
+	})
+	ResponseEntity<Void> notifyContentImageSaveSuccess(@RequestBody final NotifyContentImageSaveSuccessRequest request);
+}

--- a/src/main/java/com/notitime/noffice/api/image/presentation/ContentImageController.java
+++ b/src/main/java/com/notitime/noffice/api/image/presentation/ContentImageController.java
@@ -1,0 +1,39 @@
+package com.notitime.noffice.api.image.presentation;
+
+import com.notitime.noffice.api.image.business.ContentImageService;
+import com.notitime.noffice.api.image.business.dto.ContentImagePresignedUrlVO;
+import com.notitime.noffice.api.image.business.dto.ImagePurpose;
+import com.notitime.noffice.api.image.business.dto.NotifyContentImageSaveSuccessRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/image")
+public class ContentImageController implements ContentImageApi {
+
+	private final ContentImageService contentImageService;
+
+	@GetMapping
+	public ResponseEntity<ContentImagePresignedUrlVO> getContentImage(@RequestParam final String fileType,
+	                                                                  @RequestParam final String fileName,
+	                                                                  @RequestParam final ImagePurpose imagePurpose
+	) {
+		return ResponseEntity
+				.ok(ContentImagePresignedUrlVO.of(fileName,
+						contentImageService.getPresignedUrl(fileType, fileName, imagePurpose)));
+	}
+
+	@PostMapping
+	public ResponseEntity<Void> notifyContentImageSaveSuccess(
+			@RequestBody final NotifyContentImageSaveSuccessRequest request) {
+		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
+}

--- a/src/main/java/com/notitime/noffice/api/member/presentation/MemberController.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/MemberController.java
@@ -9,7 +9,6 @@ import com.notitime.noffice.request.SocialAuthRequest;
 import com.notitime.noffice.response.MemberResponse;
 import com.notitime.noffice.response.SocialAuthResponse;
 import com.notitime.noffice.response.TokenResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "회원", description = "회원 로그인, 정보 조회 API")
 @RestController
 @RequestMapping("/api/v1/member")
 @RequiredArgsConstructor

--- a/src/main/java/com/notitime/noffice/domain/image/model/ContentImage.java
+++ b/src/main/java/com/notitime/noffice/domain/image/model/ContentImage.java
@@ -1,0 +1,39 @@
+package com.notitime.noffice.domain.image.model;
+
+import com.notitime.noffice.api.image.business.dto.ImagePurpose;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class ContentImage {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(length = 1000)
+	private String title;
+
+	@Column(name = "image_url", length = 1000)
+	private String imageUrl;
+
+	@Column(name = "image_type")
+	@Enumerated(EnumType.STRING)
+	private ImagePurpose imagePurpose;
+
+	public ContentImage(String title, String imageUrl, ImagePurpose imagePurpose) {
+		this.title = title;
+		this.imageUrl = imageUrl;
+		this.imagePurpose = imagePurpose;
+	}
+}

--- a/src/main/java/com/notitime/noffice/domain/image/persistence/ContentImageRepository.java
+++ b/src/main/java/com/notitime/noffice/domain/image/persistence/ContentImageRepository.java
@@ -1,0 +1,7 @@
+package com.notitime.noffice.domain.image.persistence;
+
+import com.notitime.noffice.domain.image.model.ContentImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContentImageRepository extends JpaRepository<ContentImage, Long> {
+}

--- a/src/main/java/com/notitime/noffice/global/config/S3Config.java
+++ b/src/main/java/com/notitime/noffice/global/config/S3Config.java
@@ -1,0 +1,37 @@
+package com.notitime.noffice.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class S3Config {
+
+	@Value("${aws.access-key}")
+	private String accessKey;
+
+	@Value("${aws.secret-key}")
+	private String secretKey;
+
+	@Value("${aws.region}")
+	private String region;
+
+	@Bean
+	@Primary
+	public BasicAWSCredentials awsCredentialsProvider() {
+		return new BasicAWSCredentials(accessKey, secretKey);
+	}
+
+	@Bean
+	public AmazonS3 getS3Client() {
+		return AmazonS3ClientBuilder.standard()
+				.withRegion(region)
+				.withCredentials(new AWSStaticCredentialsProvider(awsCredentialsProvider()))
+				.build();
+	}
+}

--- a/src/main/java/com/notitime/noffice/global/config/SecurityWhiteListPaths.java
+++ b/src/main/java/com/notitime/noffice/global/config/SecurityWhiteListPaths.java
@@ -10,6 +10,8 @@ public class SecurityWhiteListPaths {
 	public static final String[] SECURITY_WHITE_LIST = {
 			"/error",
 			"/api/v1/member/login",
+			"/api/v1/image/**",
+			"/image/**",
 			"/h2-console/**",
 			"/swagger-ui/**",
 			"/swagger-resources/**",
@@ -20,7 +22,9 @@ public class SecurityWhiteListPaths {
 
 	public static final List<String> FILTER_WHITE_LIST = List.of(
 			"/health/**",
+			"/image/**",
 			"/api/v1/auth/google/callback",
+			"/api/v1/image/**",
 			"/api/v1/member/login",
 			"/swagger-ui/**",
 			"/swagger-resources/**",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,3 +64,9 @@ oauth:
     team-id: ${APPLE_TEAM_ID}
     audience: https://appleid.apple.com
     private-key: ${APPLE_PRIVATE_KEY}
+  
+aws:
+  access-key: ${AWS_ACCESS_KEY}
+  secret-key: ${AWS_SECRET_KEY}
+  region: ${AWS_REGION}
+  s3-bucket-name: ${AWS_S3_BUCKET_NAME}


### PR DESCRIPTION
## 🚀 Related Issue

close: #18 

## 📌 Tasks

- S3 이미지 업로드 기능 구현
- `GET` : /api/v1/image  | 이미지 발송을 위한 Presigned URL을 발급합니다.
- `POST` : /api/v1/image  | 이미지를 Presigned URL로 업로드한 후 , 업로드 완료 이벤트 요청을 발송합니다.

## 📝 Details

- 이미지 유형에 따른 `ImagePurpose` 엔티티를 추가하였습니다.
- 이미지 조회에 의한 검색 대상으로 사용할 수 있습니다.

## 📚 Remarks

- 스웨거 문서의 중복된 기술 항목을 제거하였습니다.
- ERD에 이미지 저장 객체의 스펙을 기술하였습니다.