### PR TITLE
✨ [Feat] 조직 생성 시 개설자는 리더 권한을 가진다

### DIFF
--- a/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationController.java
+++ b/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationController.java
@@ -52,7 +52,7 @@ public class OrganizationController implements OrganizationApi {
 	public NofficeResponse<OrganizationCreateResponse> createOrganization(@AuthMember final Long memberId,
 	                                                                      @RequestBody @Valid final OrganizationCreateRequest request) {
 		return NofficeResponse.success(BusinessSuccessCode.CREATE_ORGANIZATION_SUCCESS,
-				organizationService.createOrganization(request));
+				organizationService.createOrganization(memberId, request));
 	}
 
 	@PostMapping("/{organizationId}/join")

--- a/src/main/java/com/notitime/noffice/domain/organization/model/Organization.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/model/Organization.java
@@ -3,6 +3,7 @@ package com.notitime.noffice.domain.organization.model;
 import com.notitime.noffice.domain.BaseTimeEntity;
 import com.notitime.noffice.domain.announcement.model.Announcement;
 import com.notitime.noffice.domain.category.model.Category;
+import com.notitime.noffice.domain.member.model.Member;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -46,9 +47,11 @@ public class Organization extends BaseTimeEntity {
 	@OneToMany(mappedBy = "organization", cascade = CascadeType.ALL, orphanRemoval = true)
 	private final List<OrganizationMember> members = new ArrayList<>();
 
-	public Organization addCategories(List<Category> categories) {
-		categories.forEach(category -> this.categories.add(new OrganizationCategory(this, category)));
-		return this;
+	public static Organization create(String name, LocalDateTime endAt, String profileImage,
+	                                  List<Category> categories, Member leader) {
+		Organization organization = new Organization(name, endAt, profileImage, categories);
+		organization.addLeader(leader);
+		return organization;
 	}
 
 	public void updateCategories(List<Category> categories) {
@@ -58,5 +61,20 @@ public class Organization extends BaseTimeEntity {
 			}
 		}
 		this.categories.removeIf(oc -> categories.stream().noneMatch(category -> oc.getCategory().equals(category)));
+	}
+
+	private Organization(String name, LocalDateTime endAt, String profileImage, List<Category> categories) {
+		this.name = name;
+		this.endAt = endAt;
+		this.profileImage = profileImage;
+		addCategories(categories);
+	}
+
+	private void addCategories(List<Category> categories) {
+		categories.forEach(category -> this.categories.add(new OrganizationCategory(this, category)));
+	}
+
+	private void addLeader(Member leader) {
+		this.members.add(OrganizationMember.create(this, leader));
 	}
 }

--- a/src/main/java/com/notitime/noffice/domain/organization/model/OrganizationMember.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/model/OrganizationMember.java
@@ -1,5 +1,10 @@
 package com.notitime.noffice.domain.organization.model;
 
+import static com.notitime.noffice.domain.JoinStatus.ACTIVE;
+import static com.notitime.noffice.domain.JoinStatus.PENDING;
+import static com.notitime.noffice.domain.OrganizationRole.LEADER;
+import static com.notitime.noffice.domain.OrganizationRole.PARTICIPANT;
+
 import com.notitime.noffice.domain.JoinStatus;
 import com.notitime.noffice.domain.OrganizationRole;
 import com.notitime.noffice.domain.member.model.Member;
@@ -13,11 +18,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class OrganizationMember {
 
@@ -39,10 +46,11 @@ public class OrganizationMember {
 	@JoinColumn(name = "member_id")
 	private Member member;
 
-	public OrganizationMember(Organization organization, Member member) {
-		this.organization = organization;
-		this.member = member;
-		this.role = OrganizationRole.GUEST;
-		this.status = JoinStatus.PENDING;
+	public static OrganizationMember join(Organization organization, Member member) {
+		return new OrganizationMember(null, PARTICIPANT, PENDING, organization, member);
+	}
+
+	public static OrganizationMember create(Organization organization, Member member) {
+		return new OrganizationMember(null, LEADER, ACTIVE, organization, member);
 	}
 }


### PR DESCRIPTION
## 🚀 Related Issue

close: #

## 📌 Tasks

- #91 에 따른 추가 기능 설계입니다.

## 📝 Details

- 조직이 생성될 때, 조직을 개설한 사용자는 자동적으로 아래 권한을 갖도록 변경됩니다.
- 조직 내 `LEADER` 권한 부여
- 조직 내 멤버 리스트에 추가

## 📚 Remarks
