### PR TITLE
🔨  [Fix] 가입 조직 조회 쿼리 반환타입 오류 수정

### DIFF
--- a/src/main/java/com/notitime/noffice/domain/organization/persistence/OrganizationMemberRepository.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/persistence/OrganizationMemberRepository.java
@@ -18,7 +18,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface OrganizationMemberRepository extends JpaRepository<OrganizationMember, Long> {
-	List<OrganizationMember> findByMemberId(Long memberId);
+	Optional<OrganizationMember> findByOrganizationIdAndMemberId(Long organizationId, Long memberId);
 
 	@Query("SELECT om.organization FROM OrganizationMember om WHERE om.member.id = :memberId")
 	Slice<Organization> findOrganizationsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
@@ -43,9 +43,6 @@ public interface OrganizationMemberRepository extends JpaRepository<Organization
 		return findMembersByOrganizationIdAndRole(organizationId, PARTICIPANT);
 	}
 
-	boolean existsByMemberIdAndOrganizationIdAndRole(Long memberId, Long organizationId,
-	                                                 OrganizationRole organizationRole);
-
 	boolean existsByMemberIdAndOrganizationIdAndStatus(Long memberId, Long organizationId, JoinStatus status);
 
 	boolean existsByMemberIdAndOrganizationIdAndRoleAndStatus(Long memberId, Long organizationId, OrganizationRole role,
@@ -58,6 +55,4 @@ public interface OrganizationMemberRepository extends JpaRepository<Organization
 	@Query("SELECT om.member.id FROM OrganizationMember om WHERE om.organization.id = :organizationId AND om.member.id IN :memberIds AND om.status = 'ACTIVE'")
 	List<Long> findActiveMemberIdsByOrganizationId(@Param("organizationId") Long organizationId,
 	                                               @Param("memberIds") List<Long> memberIds);
-
-	Optional<OrganizationRole> findRoleByOrganizationIdAndMemberId(Long organizationId, Long memberId);
 }


### PR DESCRIPTION
## 🚀 Related Issue

close: #97 

## 📌 Tasks

- 가입 조직 조회 쿼리 메소드의 반환 타입을 `OrganizationMember`로 변경했습니다.

## 📝 Details

```
	Optional<OrganizationRole> findRoleByOrganizationIdAndMemberId(Long organizationId, Long memberId);
	Optional<OrganizationMember> findByOrganizationIdAndMemberId(Long organizationId, Long memberId);
```

해당 메소드의 projection 과정이 올바르지 않아 역할 필드를 가져오지 않았습니다.
쿼리를 명시하는 프로젝션을 사용하기보다, 객체를 가져온 뒤에 `getRole()`로 반환하였습니다.

## 📚 Remarks

- 객체 자체가 `사용자의 조직 정보`를 컨텍스트로 가지기에 객체 전체를 service layer에서 사용하는 의미가 있습니다. 