### PR TITLE
📝 [Docs] Swagger Autogen Schema responseType 수정

### DIFF
--- a/src/main/java/com/notitime/noffice/api/announcement/presentation/AnnouncementApi.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/presentation/AnnouncementApi.java
@@ -9,6 +9,7 @@ import com.notitime.noffice.response.AnnouncementResponses;
 import com.notitime.noffice.response.TaskResponses;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -32,31 +33,32 @@ public interface AnnouncementApi {
 	NofficeResponse<AnnouncementResponse> createAnnouncement(
 			@RequestBody final AnnouncementCreateRequest announcementCreateRequest);
 
-	@Operation(summary = "조직에 발급된 노티 열람", description = "열람하려는 노티를 조회하고, 열람 기록에 추가합니다.", responses = {
+	@Operation(summary = "[인증] 조직에 발급된 노티 열람", description = "열람하려는 노티를 조회하고, 열람 기록에 추가합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "노티 단일 조회 성공"),
 			@ApiResponse(responseCode = "404", description = "해당 노티가 없습니다.")
 	})
-	NofficeResponse<AnnouncementResponse> readAnnouncement(@AuthMember final Long memberId,
+	NofficeResponse<AnnouncementResponse> readAnnouncement(@Parameter(hidden = true) @AuthMember final Long memberId,
 	                                                       @PathVariable final Long announcementId);
 
-	@Operation(summary = "노티 수정", description = "노티를 수정합니다.", responses = {
+	@Operation(summary = "[인증] 노티 수정", description = "노티를 수정합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "노티 수정 성공"),
 			@ApiResponse(responseCode = "404", description = "해당 노티가 없습니다.")
 	})
-	NofficeResponse<AnnouncementResponse> updateAnnouncement(@PathVariable final Long announcementId,
+	NofficeResponse<AnnouncementResponse> updateAnnouncement(@Parameter(hidden = true) @AuthMember final Long memberId,
+	                                                         @PathVariable final Long announcementId,
 	                                                         @RequestBody final AnnouncementUpdateRequest announcementUpdateRequest);
 
-	@Operation(summary = "노티 삭제", description = "노티를 삭제합니다.", responses = {
+	@Operation(summary = "[인증] 노티 삭제", description = "노티를 삭제합니다.", responses = {
 			@ApiResponse(responseCode = "204", description = "노티 삭제 성공"),
 			@ApiResponse(responseCode = "400", description = "노티 삭제에 실패하였습니다.")
 	})
 	NofficeResponse<Void> deleteAnnouncement(@PathVariable final Long announcementId);
 
-	@Operation(summary = "노티에 발급된 투두 조회", description = "노티에 발급된 투두를 조회합니다.", responses = {
+	@Operation(summary = "[인증] 노티에 발급된 투두 조회", description = "노티에 발급된 투두를 조회합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "노티에 발급된 투두 조회 성공"),
 			@ApiResponse(responseCode = "404", description = "노티에 발급된 투두가 없습니다.")
 	})
-	NofficeResponse<TaskResponses> getTasksById(@AuthMember final Long memberId,
+	NofficeResponse<TaskResponses> getTasksById(@Parameter(hidden = true) @AuthMember final Long memberId,
 	                                            @PathVariable final Long announcementId);
 
 	@Operation(summary = "노티에 발급된 투두 삭제", description = "노티에 발급된 투두를 삭제합니다.", responses = {

--- a/src/main/java/com/notitime/noffice/api/announcement/presentation/AnnouncementApi.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/presentation/AnnouncementApi.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 
 @Tag(name = "노티", description = "노티(조직 내 공지) 관련 API")
-public interface AnnouncementApi {
+interface AnnouncementApi {
 
 	@Hidden
 	@Operation(summary = "미사용 - 사용자에게 할당된 모든 노티 조회", description = "사용자에게 할당된 모든 노티를 조회합니다.", responses = {
@@ -30,29 +30,29 @@ public interface AnnouncementApi {
 			@ApiResponse(responseCode = "201", description = "노티 생성 성공"),
 			@ApiResponse(responseCode = "400", description = "노티 생성 실패")
 	})
-	NofficeResponse<AnnouncementResponse> createAnnouncement(
+	NofficeResponse<AnnouncementResponse> create(
 			@RequestBody final AnnouncementCreateRequest announcementCreateRequest);
 
 	@Operation(summary = "[인증] 조직에 발급된 노티 열람", description = "열람하려는 노티를 조회하고, 열람 기록에 추가합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "노티 단일 조회 성공"),
 			@ApiResponse(responseCode = "404", description = "해당 노티가 없습니다.")
 	})
-	NofficeResponse<AnnouncementResponse> readAnnouncement(@Parameter(hidden = true) @AuthMember final Long memberId,
-	                                                       @PathVariable final Long announcementId);
+	NofficeResponse<AnnouncementResponse> read(@Parameter(hidden = true) @AuthMember final Long memberId,
+	                                           @PathVariable final Long announcementId);
 
 	@Operation(summary = "[인증] 노티 수정", description = "노티를 수정합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "노티 수정 성공"),
 			@ApiResponse(responseCode = "404", description = "해당 노티가 없습니다.")
 	})
-	NofficeResponse<AnnouncementResponse> updateAnnouncement(@Parameter(hidden = true) @AuthMember final Long memberId,
-	                                                         @PathVariable final Long announcementId,
-	                                                         @RequestBody final AnnouncementUpdateRequest announcementUpdateRequest);
+	NofficeResponse<AnnouncementResponse> update(@Parameter(hidden = true) @AuthMember final Long memberId,
+	                                             @PathVariable final Long announcementId,
+	                                             @RequestBody final AnnouncementUpdateRequest announcementUpdateRequest);
 
 	@Operation(summary = "[인증] 노티 삭제", description = "노티를 삭제합니다.", responses = {
 			@ApiResponse(responseCode = "204", description = "노티 삭제 성공"),
 			@ApiResponse(responseCode = "400", description = "노티 삭제에 실패하였습니다.")
 	})
-	NofficeResponse<Void> deleteAnnouncement(@PathVariable final Long announcementId);
+	NofficeResponse<Void> delete(@PathVariable final Long announcementId);
 
 	@Operation(summary = "[인증] 노티에 발급된 투두 조회", description = "노티에 발급된 투두를 조회합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "노티에 발급된 투두 조회 성공"),

--- a/src/main/java/com/notitime/noffice/api/announcement/presentation/AnnouncementController.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/presentation/AnnouncementController.java
@@ -41,29 +41,29 @@ public class AnnouncementController implements AnnouncementApi {
 	}
 
 	@PostMapping
-	public NofficeResponse<AnnouncementResponse> createAnnouncement(
+	public NofficeResponse<AnnouncementResponse> create(
 			@RequestBody final AnnouncementCreateRequest announcementCreateRequest) {
 		return NofficeResponse.success(POST_ANNOUNCEMENT_SUCCESS,
 				announcementService.createAnnouncement(announcementCreateRequest));
 	}
 
 	@GetMapping("/{announcementId}")
-	public NofficeResponse<AnnouncementResponse> readAnnouncement(@AuthMember final Long memberId,
-	                                                              @PathVariable final Long announcementId) {
+	public NofficeResponse<AnnouncementResponse> read(@AuthMember final Long memberId,
+	                                                  @PathVariable final Long announcementId) {
 		return NofficeResponse.success(GET_ANNOUNCEMENT_SUCCESS,
 				announcementService.readAnnouncement(memberId, announcementId));
 	}
 
 	@PostMapping("/{announcementId}")
-	public NofficeResponse<AnnouncementResponse> updateAnnouncement(@AuthMember final Long memberId,
-	                                                                @PathVariable final Long announcementId,
-	                                                                @RequestBody final AnnouncementUpdateRequest announcementUpdateRequest) {
+	public NofficeResponse<AnnouncementResponse> update(@AuthMember final Long memberId,
+	                                                    @PathVariable final Long announcementId,
+	                                                    @RequestBody final AnnouncementUpdateRequest announcementUpdateRequest) {
 		return NofficeResponse.success(PUT_ANNOUNCEMENT_SUCCESS,
 				announcementService.updateAnnouncement(announcementId, announcementUpdateRequest));
 	}
 
 	@DeleteMapping("/{announcementId}")
-	public NofficeResponse<Void> deleteAnnouncement(@PathVariable final Long announcementId) {
+	public NofficeResponse<Void> delete(@PathVariable final Long announcementId) {
 		announcementService.deleteAnnouncement(announcementId);
 		return NofficeResponse.success(DELETE_ANNOUNCEMENT_SUCCESS);
 	}

--- a/src/main/java/com/notitime/noffice/api/announcement/presentation/AnnouncementController.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/presentation/AnnouncementController.java
@@ -55,7 +55,8 @@ public class AnnouncementController implements AnnouncementApi {
 	}
 
 	@PostMapping("/{announcementId}")
-	public NofficeResponse<AnnouncementResponse> updateAnnouncement(@PathVariable final Long announcementId,
+	public NofficeResponse<AnnouncementResponse> updateAnnouncement(@AuthMember final Long memberId,
+	                                                                @PathVariable final Long announcementId,
 	                                                                @RequestBody final AnnouncementUpdateRequest announcementUpdateRequest) {
 		return NofficeResponse.success(PUT_ANNOUNCEMENT_SUCCESS,
 				announcementService.updateAnnouncement(announcementId, announcementUpdateRequest));

--- a/src/main/java/com/notitime/noffice/api/member/presentation/MemberApi.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/MemberApi.java
@@ -7,6 +7,7 @@ import com.notitime.noffice.response.MemberResponse;
 import com.notitime.noffice.response.SocialAuthResponse;
 import com.notitime.noffice.response.TokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,8 +25,8 @@ public interface MemberApi {
 	})
 	NofficeResponse<TokenResponse> reissue(@RequestHeader("Authorization") final String refreshToken);
 
-	@Operation(summary = "단일 회원 정보 조회", description = "회원의 정보를 조회합니다.", responses = {
+	@Operation(summary = "[인증] 단일 회원 정보 조회", description = "회원의 정보를 조회합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "회원 정보 조회에 성공하였습니다.")
 	})
-	NofficeResponse<MemberResponse> getMember(@AuthMember final Long memberId);
+	NofficeResponse<MemberResponse> getMember(@Parameter(hidden = true) @AuthMember final Long memberId);
 }

--- a/src/main/java/com/notitime/noffice/api/member/presentation/MemberApi.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/MemberApi.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "회원", description = "회원 로그인, 정보 조회 API")
-public interface MemberApi {
+interface MemberApi {
 	@Operation(summary = "회원 로그인", description = "본문에 소셜 공급자명과 인가코드를 넣어 노피스 서버 로그인을 시도합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "로그인에 성공하였습니다.")
 	})
@@ -28,5 +28,5 @@ public interface MemberApi {
 	@Operation(summary = "[인증] 단일 회원 정보 조회", description = "회원의 정보를 조회합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "회원 정보 조회에 성공하였습니다.")
 	})
-	NofficeResponse<MemberResponse> getMember(@Parameter(hidden = true) @AuthMember final Long memberId);
+	NofficeResponse<MemberResponse> getById(@Parameter(hidden = true) @AuthMember final Long memberId);
 }

--- a/src/main/java/com/notitime/noffice/api/member/presentation/MemberController.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/MemberController.java
@@ -1,9 +1,12 @@
 package com.notitime.noffice.api.member.presentation;
 
+import static com.notitime.noffice.global.response.BusinessSuccessCode.GET_MEMBER_SUCCESS;
+import static com.notitime.noffice.global.response.BusinessSuccessCode.POST_LOGIN_SUCCESS;
+import static com.notitime.noffice.global.response.BusinessSuccessCode.POST_REISSUE_SUCCESS;
+
 import com.notitime.noffice.api.auth.business.AuthService;
 import com.notitime.noffice.api.member.business.MemberService;
 import com.notitime.noffice.auth.AuthMember;
-import com.notitime.noffice.global.response.BusinessSuccessCode;
 import com.notitime.noffice.global.response.NofficeResponse;
 import com.notitime.noffice.request.SocialAuthRequest;
 import com.notitime.noffice.response.MemberResponse;
@@ -27,16 +30,16 @@ public class MemberController implements MemberApi {
 
 	@PostMapping("/login")
 	public NofficeResponse<SocialAuthResponse> login(@RequestBody final SocialAuthRequest socialLoginRequest) {
-		return NofficeResponse.success(BusinessSuccessCode.POST_LOGIN_SUCCESS, authService.login(socialLoginRequest));
+		return NofficeResponse.success(POST_LOGIN_SUCCESS, authService.login(socialLoginRequest));
 	}
 
 	@PostMapping("/reissue")
 	public NofficeResponse<TokenResponse> reissue(@RequestHeader("Authorization") final String refreshToken) {
-		return NofficeResponse.success(BusinessSuccessCode.POST_REISSUE_SUCCESS, authService.reissue(refreshToken));
+		return NofficeResponse.success(POST_REISSUE_SUCCESS, authService.reissue(refreshToken));
 	}
 
 	@GetMapping
-	public NofficeResponse<MemberResponse> getMember(@AuthMember final Long memberId) {
-		return NofficeResponse.success(BusinessSuccessCode.GET_MEMBER_SUCCESS, memberService.getMember(memberId));
+	public NofficeResponse<MemberResponse> getById(@AuthMember final Long memberId) {
+		return NofficeResponse.success(GET_MEMBER_SUCCESS, memberService.getMember(memberId));
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/notification/presentation/NotificationApi.java
+++ b/src/main/java/com/notitime/noffice/api/notification/presentation/NotificationApi.java
@@ -1,43 +1,47 @@
 package com.notitime.noffice.api.notification.presentation;
 
+import com.notitime.noffice.auth.AuthMember;
 import com.notitime.noffice.global.response.NofficeResponse;
 import com.notitime.noffice.request.NotificationRequest;
 import com.notitime.noffice.request.NotificationTimeChangeRequest;
 import com.notitime.noffice.response.NotificationBulkRequest;
 import com.notitime.noffice.response.NotificationTimeChangeResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "알림", description = "노티 알림 발송 관련 API")
 interface NotificationApi {
 
-	@Operation(summary = "단일 사용자 알림 대기열 추가", description = "단일 사용자를 특정하여 노티 알림 대기열에 등록합니다.", responses = {
+	@Operation(summary = "[인증] 단일 사용자 알림 대기열 추가", description = "단일 사용자를 특정하여 노티 알림 대기열에 등록합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "알림 대기열 등록 성공"),
 			@ApiResponse(responseCode = "400", description = "알림 발송 실패")
 	})
-	NofficeResponse<Void> createNotification(@RequestBody final NotificationRequest request);
+	NofficeResponse<Void> createNotification(@Parameter(hidden = true) @AuthMember final Long memberId,
+	                                         @RequestBody final NotificationRequest request);
 
-	@Operation(summary = "조직 단위 알림 대량 발송", description = "조직 내 모든 사용자에게 전체 발송되는 알림을 등록합니다.", responses = {
+	@Operation(summary = "[인증] 조직 단위 알림 대량 발송", description = "조직 내 모든 사용자에게 전체 발송되는 알림을 등록합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "조직 전체 알림 대량 등록 성공"),
 			@ApiResponse(responseCode = "400", description = "조직 전체 알림 대량 등록 실패")
 	})
-	NofficeResponse<Void> createBulkNotification(@RequestBody final NotificationBulkRequest request);
+	NofficeResponse<Void> createBulkNotification(@Parameter(hidden = true) @AuthMember final Long memberId,
+	                                             @RequestBody final NotificationBulkRequest request);
 
-	@Operation(summary = "사용자에게 수신된 알림 조회", description = "사용자에게 수신된 알림을 조회합니다.", responses = {
+	@Operation(summary = "[인증] 사용자에게 수신된 알림 조회", description = "사용자에게 수신된 알림을 조회합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "알림 조회 성공"),
 			@ApiResponse(responseCode = "404", description = "알림이 없습니다.")
 	})
-	NofficeResponse<Void> getNotifications(@RequestParam final Long memberId);
+	NofficeResponse<Void> getNotifications(@Parameter(hidden = true) @AuthMember final Long memberId);
 
-	@Operation(summary = "알림 발송 시간 변경", description = "노티 알림 발송 시간을 변경합니다.", responses = {
+	@Operation(summary = "[인증] 알림 발송 시간 변경", description = "노티 알림 발송 시간을 변경합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "알림 발송 시간 변경 성공"),
 			@ApiResponse(responseCode = "400", description = "알림 발송 시간 변경 실패")
 	})
 	NofficeResponse<NotificationTimeChangeResponse> changeSendTime(
+			@Parameter(hidden = true) @AuthMember final Long memberId,
 			@RequestBody final NotificationTimeChangeRequest request);
 
 	@Operation(summary = "알림 삭제", description = "노티 알림을 삭제합니다.", responses = {

--- a/src/main/java/com/notitime/noffice/api/notification/presentation/NotificationApi.java
+++ b/src/main/java/com/notitime/noffice/api/notification/presentation/NotificationApi.java
@@ -20,21 +20,21 @@ interface NotificationApi {
 			@ApiResponse(responseCode = "200", description = "알림 대기열 등록 성공"),
 			@ApiResponse(responseCode = "400", description = "알림 발송 실패")
 	})
-	NofficeResponse<Void> createNotification(@Parameter(hidden = true) @AuthMember final Long memberId,
-	                                         @RequestBody final NotificationRequest request);
+	NofficeResponse<Void> create(@Parameter(hidden = true) @AuthMember final Long memberId,
+	                             @RequestBody final NotificationRequest request);
 
 	@Operation(summary = "[인증] 조직 단위 알림 대량 발송", description = "조직 내 모든 사용자에게 전체 발송되는 알림을 등록합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "조직 전체 알림 대량 등록 성공"),
 			@ApiResponse(responseCode = "400", description = "조직 전체 알림 대량 등록 실패")
 	})
-	NofficeResponse<Void> createBulkNotification(@Parameter(hidden = true) @AuthMember final Long memberId,
-	                                             @RequestBody final NotificationBulkRequest request);
+	NofficeResponse<Void> createAll(@Parameter(hidden = true) @AuthMember final Long memberId,
+	                                @RequestBody final NotificationBulkRequest request);
 
 	@Operation(summary = "[인증] 사용자에게 수신된 알림 조회", description = "사용자에게 수신된 알림을 조회합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "알림 조회 성공"),
 			@ApiResponse(responseCode = "404", description = "알림이 없습니다.")
 	})
-	NofficeResponse<Void> getNotifications(@Parameter(hidden = true) @AuthMember final Long memberId);
+	NofficeResponse<Void> findById(@Parameter(hidden = true) @AuthMember final Long memberId);
 
 	@Operation(summary = "[인증] 알림 발송 시간 변경", description = "노티 알림 발송 시간을 변경합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "알림 발송 시간 변경 성공"),
@@ -48,5 +48,5 @@ interface NotificationApi {
 			@ApiResponse(responseCode = "204", description = "알림 삭제 성공"),
 			@ApiResponse(responseCode = "400", description = "알림 삭제 실패")
 	})
-	NofficeResponse<Void> deleteNotification(@PathVariable final Long notificationId);
+	NofficeResponse<Void> delete(@PathVariable final Long notificationId);
 }

--- a/src/main/java/com/notitime/noffice/api/notification/presentation/NotificationController.java
+++ b/src/main/java/com/notitime/noffice/api/notification/presentation/NotificationController.java
@@ -1,6 +1,12 @@
 package com.notitime.noffice.api.notification.presentation;
 
-import com.notitime.noffice.global.response.BusinessSuccessCode;
+import static com.notitime.noffice.global.response.BusinessSuccessCode.CHANGE_SEND_TIME_SUCCESS;
+import static com.notitime.noffice.global.response.BusinessSuccessCode.CREATED_BULK_NOTIFICATION_SUCCESS;
+import static com.notitime.noffice.global.response.BusinessSuccessCode.CREATED_NOTIFICATION_SUCCESS;
+import static com.notitime.noffice.global.response.BusinessSuccessCode.DELETE_NOTIFICATION_SUCCESS;
+import static com.notitime.noffice.global.response.BusinessSuccessCode.OK;
+
+import com.notitime.noffice.auth.AuthMember;
 import com.notitime.noffice.global.response.NofficeResponse;
 import com.notitime.noffice.request.NotificationRequest;
 import com.notitime.noffice.request.NotificationTimeChangeRequest;
@@ -13,7 +19,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,28 +26,30 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotificationController implements NotificationApi {
 
 	@PostMapping
-	public NofficeResponse<Void> createNotification(@RequestBody final NotificationRequest request) {
-		return NofficeResponse.success(BusinessSuccessCode.CREATED_NOTIFICATION_SUCCESS);
+	public NofficeResponse<Void> create(@AuthMember final Long memberId,
+	                                    @RequestBody final NotificationRequest request) {
+		return NofficeResponse.success(CREATED_NOTIFICATION_SUCCESS);
 	}
 
 	@PostMapping("/bulk")
-	public NofficeResponse<Void> createBulkNotification(@RequestBody final NotificationBulkRequest request) {
-		return NofficeResponse.success(BusinessSuccessCode.CREATED_BULK_NOTIFICATION_SUCCESS);
+	public NofficeResponse<Void> createAll(@AuthMember final Long memberId,
+	                                       @RequestBody final NotificationBulkRequest request) {
+		return NofficeResponse.success(CREATED_BULK_NOTIFICATION_SUCCESS);
 	}
 
 	@GetMapping
-	public NofficeResponse<Void> getNotifications(@RequestParam final Long memberId) {
-		return NofficeResponse.success(BusinessSuccessCode.OK);
+	public NofficeResponse<Void> findById(@AuthMember final Long memberId) {
+		return NofficeResponse.success(OK);
 	}
 
 	@PatchMapping
-	public NofficeResponse<NotificationTimeChangeResponse> changeSendTime(
-			@RequestBody final NotificationTimeChangeRequest request) {
-		return NofficeResponse.success(BusinessSuccessCode.CHANGE_SEND_TIME_SUCCESS);
+	public NofficeResponse<NotificationTimeChangeResponse> changeSendTime(@AuthMember final Long memberId,
+	                                                                      @RequestBody final NotificationTimeChangeRequest request) {
+		return NofficeResponse.success(CHANGE_SEND_TIME_SUCCESS);
 	}
 
 	@DeleteMapping("/{notificationId}")
-	public NofficeResponse<Void> deleteNotification(@PathVariable final Long notificationId) {
-		return NofficeResponse.success(BusinessSuccessCode.DELETE_NOTIFICATION_SUCCESS);
+	public NofficeResponse<Void> delete(@PathVariable final Long notificationId) {
+		return NofficeResponse.success(DELETE_NOTIFICATION_SUCCESS);
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationApi.java
+++ b/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationApi.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "조직", description = "조직 관련 API")
-public interface OrganizationApi {
+interface OrganizationApi {
 
 	@Operation(summary = "[인증] 단일 조직 정보 조회", description = "조직의 정보(조직명, 가입 대기여부, 가입자수) 를 조회합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "조직 정보 조회에 성공하였습니다."),

--- a/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationApi.java
+++ b/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationApi.java
@@ -11,6 +11,7 @@ import com.notitime.noffice.request.OrganizationCreateRequest;
 import com.notitime.noffice.response.AnnouncementCoverResponse;
 import com.notitime.noffice.response.CategoryModifyResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -22,33 +23,34 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "조직", description = "조직 관련 API")
 public interface OrganizationApi {
 
-	@Operation(summary = "단일 조직 정보 조회", description = "조직의 정보(조직명, 가입 대기여부, 가입자수) 를 조회합니다.", responses = {
+	@Operation(summary = "[인증] 단일 조직 정보 조회", description = "조직의 정보(조직명, 가입 대기여부, 가입자수) 를 조회합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "조직 정보 조회에 성공하였습니다."),
 			@ApiResponse(responseCode = "404", description = "조직 정보가 없습니다.")
 	})
-	NofficeResponse<OrganizationInfoResponse> getInformation(@AuthMember Long memberId,
+	NofficeResponse<OrganizationInfoResponse> getInformation(@Parameter(hidden = true) @AuthMember Long memberId,
 	                                                         @PathVariable Long organizationId);
 
-	@Operation(summary = "조직 생성", description = "조직을 생성합니다.", responses = {
+	@Operation(summary = "[인증] 조직 생성", description = "조직을 생성합니다.", responses = {
 			@ApiResponse(responseCode = "201", description = "조직 생성에 성공하였습니다."),
 			@ApiResponse(responseCode = "400", description = "조직 생성에 실패하였습니다.")
 	})
-	NofficeResponse<OrganizationCreateResponse> create(@AuthMember Long memberId,
+	NofficeResponse<OrganizationCreateResponse> create(@Parameter(hidden = true) @AuthMember final Long memberId,
 	                                                   @RequestBody @Valid final OrganizationCreateRequest request);
 
-	@Operation(summary = "조직 가입", description = "조직에 가입합니다.", responses = {
+	@Operation(summary = "[인증] 조직 가입", description = "조직에 가입합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "조직 가입에 성공하였습니다.")
 	})
-	NofficeResponse<OrganizationJoinResponse> join(@AuthMember Long memberId,
+	NofficeResponse<OrganizationJoinResponse> join(@Parameter(hidden = true) @AuthMember final Long memberId,
 	                                               @PathVariable Long organizationId);
 
-	@Operation(summary = "사용자의 가입된 조직 페이징 조회", description = "멤버가 가입한 조직 목록을 조회합니다.", responses = {
+	@Operation(summary = "[인증] 사용자의 가입된 조직 페이징 조회", description = "멤버가 가입한 조직 목록을 조회합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "회원의 가입된 조직 조회에 성공하였습니다."),
 			@ApiResponse(responseCode = "404", description = "가입된 조직이 없습니다.")
 	})
-	NofficeResponse<Slice<OrganizationResponse>> getJoined(@AuthMember Long memberId, Pageable pageable);
+	NofficeResponse<Slice<OrganizationResponse>> getJoined(@Parameter(hidden = true) @AuthMember final Long memberId,
+	                                                       Pageable pageable);
 
-	@Operation(summary = "조직별 노티 페이징 조회", description = "조직별 노티를 페이징 조회합니다.", responses = {
+	@Operation(summary = "[인증] 조직별 노티 페이징 조회", description = "조직별 노티를 페이징 조회합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "조직별 노티 페이징 조회 성공"),
 			@ApiResponse(responseCode = "404", description = "조직에 등록된 노티가 없습니다.")
 	})
@@ -56,7 +58,7 @@ public interface OrganizationApi {
 	                                                                            @PathVariable final Long organizationId,
 	                                                                            Pageable pageable);
 
-	@Operation(summary = "조직 카테고리 수정", description = "조직에 등록된 카테고리를 수정합니다.", responses = {
+	@Operation(summary = "[인증] 조직 카테고리 수정", description = "조직에 등록된 카테고리를 수정합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "조직 카테고리 수정 성공"),
 			@ApiResponse(responseCode = "404", description = "조직에 등록된 카테고리가 없습니다.")
 	})
@@ -64,12 +66,13 @@ public interface OrganizationApi {
 	                                                         @PathVariable final Long organizationId,
 	                                                         @RequestBody @Valid final CategoryModifyRequest request);
 
-	@Operation(summary = "조직원 권한 변경", description = "타겟에 해당하는 멤버의 조직 내 권한을 입력한 권한대로 변경합니다.", responses = {
+	@Operation(summary = "[인증] 조직원 권한 변경", description = "타겟에 해당하는 멤버의 조직 내 권한을 입력한 권한대로 변경합니다.", responses = {
 			@ApiResponse(responseCode = "204", description = "권한 변경에 성공하였습니다."),
 			@ApiResponse(responseCode = "400", description = "권한 변경에 실패하였습니다."),
 			@ApiResponse(responseCode = "403", description = "요청을 수행할 수 있는 권한이 없습니다."),
 			@ApiResponse(responseCode = "404", description = "조직원이 존재하지 않습니다.")
 	})
-	NofficeResponse<Void> changeRoles(@AuthMember Long memberId, @PathVariable Long organizationId,
+	NofficeResponse<Void> changeRoles(@Parameter(hidden = true) @AuthMember Long memberId,
+	                                  @PathVariable Long organizationId,
 	                                  @RequestBody @Valid final ChangeRoleRequest request);
 }

--- a/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationController.java
+++ b/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationController.java
@@ -84,7 +84,7 @@ public class OrganizationController implements OrganizationApi {
 	}
 
 	@PatchMapping("/{organizationId}/roles")
-	public NofficeResponse<Void> changeRoles(@AuthMember Long memberId, @PathVariable Long organizationId,
+	public NofficeResponse<Void> changeRoles(@AuthMember final Long memberId, @PathVariable Long organizationId,
 	                                         @RequestBody @Valid final ChangeRoleRequest request) {
 		organizationService.changeRoles(memberId, organizationId, request);
 		return NofficeResponse.success(PATCH_CHANGE_ROLES_SUCCESS);

--- a/src/main/java/com/notitime/noffice/api/task/presentation/TaskApi.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/TaskApi.java
@@ -6,6 +6,7 @@ import com.notitime.noffice.request.TaskModifyRequest;
 import com.notitime.noffice.response.AssignedTaskResponse;
 import com.notitime.noffice.response.TaskModifyResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
@@ -24,5 +25,6 @@ interface TaskApi {
 			@ApiResponse(responseCode = "200", description = "사용자 할당 투두 조회 성공"),
 			@ApiResponse(responseCode = "404", description = "사용자 할당된 투두가 없습니다.")
 	})
-	NofficeResponse<Slice<AssignedTaskResponse>> getAssigned(@AuthMember Long memberId, Pageable pageable);
+	NofficeResponse<Slice<AssignedTaskResponse>> getAssigned(@Parameter(hidden = true) @AuthMember final Long memberId,
+	                                                         Pageable pageable);
 }

--- a/src/main/java/com/notitime/noffice/api/task/presentation/TaskController.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/TaskController.java
@@ -31,7 +31,8 @@ public class TaskController implements TaskApi {
 	}
 
 	@GetMapping("/assigned")
-	public NofficeResponse<Slice<AssignedTaskResponse>> getAssigned(@AuthMember Long memberId, Pageable pageable) {
+	public NofficeResponse<Slice<AssignedTaskResponse>> getAssigned(@AuthMember final Long memberId,
+	                                                                Pageable pageable) {
 		return NofficeResponse.success(GET_ASSIGNED_TASKS_SUCCESS,
 				taskService.getAssignedTasks(memberId, pageable));
 	}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,5 +17,5 @@ springdoc:
   api-docs:
     path: /v3/api-docs
   paths-to-match: /api/**
-  default-consumes-media-type: application/json;charset=UTF-8
-  default-produces-media-type: application/json;charset=UTF-8
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json


### PR DESCRIPTION
## 🚀 Related Issue

close: #99 

## 📌 Tasks

- Swagger Autogen Schema responseType 수정

## 📝 Details

- JWT 토큰으로 인증하는 메소드는 `memberId` parameter 문서 숨김처리
- 인증이 요구되는 메소드의 여부 `description` 기술
- 컨트롤러 내 메소드 네이밍 통일 (entity 명 제외)

## 📚 Remarks

- [Swagger UI](http://localhost:8080/api-docs)