### PR TITLE
:hammer: [Fix] 공지 열람 API 트랜잭션 전략 변경

### DIFF
--- a/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
@@ -37,7 +37,6 @@ public class AnnouncementService {
 	private final RoleVerifier roleVerifier;
 	private final ReadStatusRecoder readStatusRecoder;
 
-	@Transactional(readOnly = true)
 	public AnnouncementResponse readAnnouncement(Long memberId, Long announcementId) {
 		roleVerifier.verifyJoinedMember(memberId, announcementId);
 		recordReadStatus(memberId, announcementId);


### PR DESCRIPTION
## 🚀 Related Issue

close: #107 

## 📌 Tasks

- 기존 : 사용자의 공지 조회 요청 내 트랜잭션 속성은 `readOnly = true`로 할당
- 변경 : 사용자 열람 정보 기록 과정에서 write 발생 -> 전역 `Transactional` 설정
 - `AnnounceService` 내 `ReadStatusRecoder` 의존성으로 인해 commit fail 되어 query가 발생하지 않았던 문제
## 📝 Details

```java
public class ReadStatusRecoder {

	private final AnnouncementReadStatusRepository announcementReadStatusRepository;

	public void record(Member member, Announcement announcement) {
		announcementReadStatusRepository.save(AnnouncementReadStatus.builder()
				.readAt(LocalDateTime.now())
				.isRead(true)
				.member(member)
				.announcement(announcement)
				.build());
	}
```

## 📚 Remarks

- 
- 