### PR TITLE
✨ [Feat] 이미지 타입별 동적 조회 전략 구성

### DIFF
--- a/src/main/java/com/notitime/noffice/api/image/presentation/dto/CommonImageResponse.java
+++ b/src/main/java/com/notitime/noffice/api/image/presentation/dto/CommonImageResponse.java
@@ -1,0 +1,15 @@
+package com.notitime.noffice.api.image.presentation.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.notitime.noffice.api.image.business.dto.ImagePurpose;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CommonImageResponse(
+		@Schema(description = "이미지 타입", requiredMode = REQUIRED, example = "ORGANIZATION_LOGO")
+		ImagePurpose type,
+		@Schema(description = "이미지 ID", requiredMode = REQUIRED, example = "1")
+		Long id,
+		@Schema(description = "이미지 URL", requiredMode = REQUIRED, example = "https://test-image.com/image.jpg")
+		String url
+) {}

--- a/src/main/java/com/notitime/noffice/api/image/strategy/AnnouncementCoverImageRetrievalStrategy.java
+++ b/src/main/java/com/notitime/noffice/api/image/strategy/AnnouncementCoverImageRetrievalStrategy.java
@@ -1,0 +1,29 @@
+package com.notitime.noffice.api.image.strategy;
+
+import static com.notitime.noffice.api.image.business.dto.ImagePurpose.ANNOUNCEMENT_PROFILE;
+
+import com.notitime.noffice.api.image.presentation.dto.CommonImageResponse;
+import com.notitime.noffice.domain.announcement.model.AnnouncementImage;
+import com.notitime.noffice.domain.announcement.persistence.AnnouncementImageRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AnnouncementCoverImageRetrievalStrategy implements ImageRetrievalStrategy<AnnouncementImage> {
+
+	private final AnnouncementImageRepository announcementImageRepository;
+
+	@Override
+	public List<CommonImageResponse> getSelectableImages(Long organizationId) {
+		return announcementImageRepository.findAll().stream()
+				.map(this::toResponse)
+				.toList();
+	}
+
+	@Override
+	public CommonImageResponse toResponse(AnnouncementImage image) {
+		return new CommonImageResponse(ANNOUNCEMENT_PROFILE, image.getId(), image.getImageUrl());
+	}
+}

--- a/src/main/java/com/notitime/noffice/api/image/strategy/ImageRetrievalContext.java
+++ b/src/main/java/com/notitime/noffice/api/image/strategy/ImageRetrievalContext.java
@@ -1,0 +1,21 @@
+package com.notitime.noffice.api.image.strategy;
+
+import com.notitime.noffice.api.image.presentation.dto.CommonImageResponse;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ImageRetrievalContext {
+	private final List<ImageRetrievalStrategy<?>> strategies;
+
+	public ImageRetrievalContext(List<ImageRetrievalStrategy<?>> strategies) {
+		this.strategies = strategies;
+	}
+
+	public List<CommonImageResponse> retrieve(Long entityIdentifier) {
+		List<CommonImageResponse> result = new ArrayList<>();
+		for (ImageRetrievalStrategy<?> strategy : strategies) {
+			result.addAll(strategy.getSelectableImages(entityIdentifier));
+		}
+		return result;
+	}
+}

--- a/src/main/java/com/notitime/noffice/api/image/strategy/ImageRetrievalStrategy.java
+++ b/src/main/java/com/notitime/noffice/api/image/strategy/ImageRetrievalStrategy.java
@@ -1,0 +1,10 @@
+package com.notitime.noffice.api.image.strategy;
+
+import com.notitime.noffice.api.image.presentation.dto.CommonImageResponse;
+import java.util.List;
+
+public interface ImageRetrievalStrategy<T> {
+	List<CommonImageResponse> getSelectableImages(Long entityId);
+
+	CommonImageResponse toResponse(T entity);
+}

--- a/src/main/java/com/notitime/noffice/api/image/strategy/PromotionImageRetrievalStrategy.java
+++ b/src/main/java/com/notitime/noffice/api/image/strategy/PromotionImageRetrievalStrategy.java
@@ -1,0 +1,29 @@
+package com.notitime.noffice.api.image.strategy;
+
+import static com.notitime.noffice.api.image.business.dto.ImagePurpose.PROMOTION_COVER;
+
+import com.notitime.noffice.api.image.presentation.dto.CommonImageResponse;
+import com.notitime.noffice.domain.promotion.PromotionImage;
+import com.notitime.noffice.domain.promotion.persistence.PromotionImageRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PromotionImageRetrievalStrategy implements ImageRetrievalStrategy<PromotionImage> {
+
+	private final PromotionImageRepository promotionImageRepository;
+
+	@Override
+	public List<CommonImageResponse> getSelectableImages(Long organizationId) {
+		return promotionImageRepository.findAll().stream()
+				.map(this::toResponse)
+				.toList();
+	}
+
+	@Override
+	public CommonImageResponse toResponse(PromotionImage image) {
+		return new CommonImageResponse(PROMOTION_COVER, image.getId(), image.getImageUrl());
+	}
+}

--- a/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationApi.java
+++ b/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationApi.java
@@ -5,6 +5,8 @@ import com.notitime.noffice.api.announcement.presentation.dto.OrganizationInfoRe
 import com.notitime.noffice.api.announcement.presentation.dto.OrganizationJoinResponse;
 import com.notitime.noffice.api.announcement.presentation.dto.OrganizationResponse;
 import com.notitime.noffice.api.announcement.presentation.dto.OrganizationSignupResponse;
+import com.notitime.noffice.api.organization.presentation.dto.ChangeRoleRequest;
+import com.notitime.noffice.api.organization.presentation.dto.OrganizationImageResponse;
 import com.notitime.noffice.auth.AuthMember;
 import com.notitime.noffice.global.response.NofficeResponse;
 import com.notitime.noffice.request.CategoryModifyRequest;
@@ -98,12 +100,21 @@ interface OrganizationApi {
 			@PathVariable final Long organizationId);
 
 	@Operation(summary = "[인증] 조직 가입 수락", description = "조직 가입대기 사용자 목록을 가입 처리합니다.", responses = {
-			@ApiResponse(responseCode = "204", description = "조직 가입 수락에 성공하였습니다."),
-			@ApiResponse(responseCode = "400", description = "조직 가입 수락에 실패하였습니다.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "204", description = "조직 가입 승인 성공"),
+			@ApiResponse(responseCode = "400", description = "조직 가입 수락 실패", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
 			@ApiResponse(responseCode = "403", description = "요청을 수행할 수 있는 권한이 없습니다.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
-			@ApiResponse(responseCode = "404", description = "조직원이 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = NofficeResponse.class)))
+			@ApiResponse(responseCode = "404", description = "조직원이 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "500", description = "서버 내부 에러 발생", content = @Content(schema = @Schema(implementation = NofficeResponse.class)))
 	})
 	NofficeResponse<Void> registerMember(@Parameter(hidden = true) @AuthMember final Long memberId,
 	                                     @PathVariable Long organizationId,
 	                                     @RequestBody final ChangeRoleRequest request);
+
+	@Operation(summary = "[인증] 선택 가능한 커버 이미지 조회", description = "공지 발행 시 선택 가능한 커버 이미지를 모두 조회합니다.", responses = {
+			@ApiResponse(responseCode = "200", description = "선택 가능한 공지 커버 이미지 목록 조회 성"),
+			@ApiResponse(responseCode = "404", description = "공지 커버 이미지가 없습니다.")
+	})
+	NofficeResponse<OrganizationImageResponse> getSelectableCover(
+			@Parameter(hidden = true) @AuthMember final Long memberId,
+			@PathVariable final Long organizationId);
 }

--- a/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationController.java
+++ b/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationController.java
@@ -5,6 +5,7 @@ import static com.notitime.noffice.global.response.BusinessSuccessCode.GET_JOINE
 import static com.notitime.noffice.global.response.BusinessSuccessCode.GET_ORGANIZATION_SUCCESS;
 import static com.notitime.noffice.global.response.BusinessSuccessCode.GET_PENDING_MEMBERS_SUCCESS;
 import static com.notitime.noffice.global.response.BusinessSuccessCode.GET_PUBLISHED_ANNOUNCEMENTS_SUCCESS;
+import static com.notitime.noffice.global.response.BusinessSuccessCode.GET_SELECTABLE_COVER_SUCCESS;
 import static com.notitime.noffice.global.response.BusinessSuccessCode.GET_SIGNUP_INFO_SUCCESS;
 import static com.notitime.noffice.global.response.BusinessSuccessCode.PATCH_CHANGE_ROLES_SUCCESS;
 import static com.notitime.noffice.global.response.BusinessSuccessCode.PATCH_REGISTER_MEMBER_SUCCESS;
@@ -18,6 +19,8 @@ import com.notitime.noffice.api.announcement.presentation.dto.OrganizationJoinRe
 import com.notitime.noffice.api.announcement.presentation.dto.OrganizationResponse;
 import com.notitime.noffice.api.announcement.presentation.dto.OrganizationSignupResponse;
 import com.notitime.noffice.api.organization.business.OrganizationService;
+import com.notitime.noffice.api.organization.presentation.dto.ChangeRoleRequest;
+import com.notitime.noffice.api.organization.presentation.dto.OrganizationImageResponse;
 import com.notitime.noffice.auth.AuthMember;
 import com.notitime.noffice.global.response.NofficeResponse;
 import com.notitime.noffice.request.CategoryModifyRequest;
@@ -115,5 +118,12 @@ public class OrganizationController implements OrganizationApi {
 	                                         @RequestBody final ChangeRoleRequest request) {
 		organizationService.changeRoles(memberId, organizationId, request);
 		return NofficeResponse.success(PATCH_CHANGE_ROLES_SUCCESS);
+	}
+
+	@GetMapping("/{organizationId}/selectable-cover")
+	public NofficeResponse<OrganizationImageResponse> getSelectableCover(@AuthMember final Long memberId,
+	                                                                     @PathVariable final Long organizationId) {
+		return NofficeResponse.success(GET_SELECTABLE_COVER_SUCCESS,
+				organizationService.getSelectableCover(memberId, organizationId));
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/organization/presentation/dto/ChangeRoleRequest.java
+++ b/src/main/java/com/notitime/noffice/api/organization/presentation/dto/ChangeRoleRequest.java
@@ -1,4 +1,4 @@
-package com.notitime.noffice.api.organization.presentation;
+package com.notitime.noffice.api.organization.presentation.dto;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 

--- a/src/main/java/com/notitime/noffice/api/organization/presentation/dto/OrganizationImageResponse.java
+++ b/src/main/java/com/notitime/noffice/api/organization/presentation/dto/OrganizationImageResponse.java
@@ -1,0 +1,19 @@
+package com.notitime.noffice.api.organization.presentation.dto;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.notitime.noffice.api.image.presentation.dto.CommonImageResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record OrganizationImageResponse(
+		@Schema(requiredMode = REQUIRED, example = "조직 ID", description = "조직 ID")
+		Long id,
+		@Schema(requiredMode = NOT_REQUIRED, description = "조직 커버 이미지 URL 리스트")
+		List<CommonImageResponse> images
+) {
+	public static OrganizationImageResponse of(Long id, List<CommonImageResponse> images) {
+		return new OrganizationImageResponse(id, images);
+	}
+}

--- a/src/main/java/com/notitime/noffice/domain/announcement/model/AnnouncementImage.java
+++ b/src/main/java/com/notitime/noffice/domain/announcement/model/AnnouncementImage.java
@@ -1,14 +1,19 @@
 package com.notitime.noffice.domain.announcement.model;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class AnnouncementImage {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
+	@Column(columnDefinition = "TEXT")
 	private String imageUrl;
 }

--- a/src/main/java/com/notitime/noffice/domain/announcement/persistence/AnnouncementImageRepository.java
+++ b/src/main/java/com/notitime/noffice/domain/announcement/persistence/AnnouncementImageRepository.java
@@ -1,0 +1,7 @@
+package com.notitime.noffice.domain.announcement.persistence;
+
+import com.notitime.noffice.domain.announcement.model.AnnouncementImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnnouncementImageRepository extends JpaRepository<AnnouncementImage, Long> {
+}

--- a/src/main/java/com/notitime/noffice/domain/promotion/PromotionImage.java
+++ b/src/main/java/com/notitime/noffice/domain/promotion/PromotionImage.java
@@ -8,9 +8,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class PromotionImage {
+	
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/src/main/java/com/notitime/noffice/global/config/ImageRetrievalConfig.java
+++ b/src/main/java/com/notitime/noffice/global/config/ImageRetrievalConfig.java
@@ -1,0 +1,16 @@
+package com.notitime.noffice.global.config;
+
+import com.notitime.noffice.api.image.strategy.ImageRetrievalContext;
+import com.notitime.noffice.api.image.strategy.ImageRetrievalStrategy;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ImageRetrievalConfig {
+
+	@Bean
+	public ImageRetrievalContext imageRetrievalContext(List<ImageRetrievalStrategy<?>> strategies) {
+		return new ImageRetrievalContext(strategies);
+	}
+}

--- a/src/main/java/com/notitime/noffice/global/response/BusinessSuccessCode.java
+++ b/src/main/java/com/notitime/noffice/global/response/BusinessSuccessCode.java
@@ -32,6 +32,7 @@ public enum BusinessSuccessCode implements SuccessCode {
 	GET_READ_MEMBERS_SUCCESS(HttpStatus.OK, "NOF-2084", "공지 열람 사용자 목록 조회 성공"),
 	GET_UNREAD_MEMBERS_SUCCESS(HttpStatus.OK, "NOF-2085", "공지 미열람 사용자 목록 조회 성공"),
 	GET_PENDING_MEMBERS_SUCCESS(HttpStatus.OK, "NOF-2086", "조직 가입 대기자 목록 조회 성공"),
+	GET_SELECTABLE_COVER_SUCCESS(HttpStatus.OK, "NOF-2087", "선택 가능한 공지 커버 이미지 목록 조회 성공"),
 
 	// CREATED (2100 ~ 2199)
 	CREATED(HttpStatus.CREATED, "NOF-210", "리소스가 생성되었습니다. - 201"),


### PR DESCRIPTION
## 🚀 Related Issue

close: #90 

## 📌 Tasks
- 선택 가능한 이미지 조회 구현 
- `GET` |  `/api/v1/organization/{organizationId}/selectable-cover`

## 📝 Details

- #80 S3 이미지 업로드에 의한 `ImagePurpose` Enum을 사전 정의
 - 해당 변수(`ImagePurpose`)는 이미지의 저장 및 사용 목적을 도메인 기준으로 명시
- 이미지의 사용처는 도메인에 따라 다르고, 해당 테이블 역시 분리된 상태
- `ImageRetrievalStrategy<T>`, `ImageRetrievalContext` 를 정의하여 이미지 엔티티는 모두 `retrive` 가능하도록 리팩토링

## 📚 Remarks

- 이미지 타입이 `AnnouncementImage`, `PromotionImage` 뿐이라 Image entity interface를 선언하지 않음. 
 - 여러 타입의 이미지를 관리하는 경우, Type check 를 통한 동등성을 interface 내에서 검증할 수 있다.