### PR TITLE
♻️ [Refactor] 조직별 투두 조회 non-paging 변경

### DIFF
--- a/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
@@ -114,6 +114,7 @@ public class AnnouncementService {
 		);
 		announcement.withTasks(request.tasks());
 		announcementRepository.save(announcement);
+		organization.addAnnouncement(announcement);
 		return announcement;
 	}
 

--- a/src/main/java/com/notitime/noffice/api/task/business/TaskService.java
+++ b/src/main/java/com/notitime/noffice/api/task/business/TaskService.java
@@ -3,19 +3,18 @@ package com.notitime.noffice.api.task.business;
 import static com.notitime.noffice.global.web.BusinessErrorCode.NOT_FOUND_ANNOUNCEMENT;
 import static com.notitime.noffice.global.web.BusinessErrorCode.NOT_FOUND_TASK;
 
-import com.notitime.noffice.domain.announcement.persistence.AnnouncementRepository;
-import com.notitime.noffice.domain.organization.model.Organization;
-import com.notitime.noffice.domain.organization.persistence.OrganizationMemberRepository;
-import com.notitime.noffice.domain.task.model.Task;
-import com.notitime.noffice.domain.task.model.TaskStatus;
-import com.notitime.noffice.domain.task.persistence.TaskRepository;
-import com.notitime.noffice.domain.task.persistence.TaskStatusRepository;
-import com.notitime.noffice.global.exception.NotFoundException;
 import com.notitime.noffice.api.task.presentation.dto.request.TaskModifyRequest;
 import com.notitime.noffice.api.task.presentation.dto.response.AssignedTaskResponse;
 import com.notitime.noffice.api.task.presentation.dto.response.TaskModifyResponse;
 import com.notitime.noffice.api.task.presentation.dto.response.TaskResponse;
 import com.notitime.noffice.api.task.presentation.dto.response.TaskResponses;
+import com.notitime.noffice.domain.announcement.persistence.AnnouncementRepository;
+import com.notitime.noffice.domain.organization.model.Organization;
+import com.notitime.noffice.domain.organization.persistence.OrganizationMemberRepository;
+import com.notitime.noffice.domain.task.model.Task;
+import com.notitime.noffice.domain.task.persistence.TaskRepository;
+import com.notitime.noffice.global.exception.NotFoundException;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageImpl;
@@ -29,7 +28,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TaskService {
 
-	private final TaskStatusRepository taskStatusRepository;
 	private final OrganizationMemberRepository organizationMemberRepository;
 	private final TaskRepository taskRepository;
 	private final AnnouncementRepository announcementRepository;
@@ -41,9 +39,8 @@ public class TaskService {
 
 	public Slice<AssignedTaskResponse> getAssignedTasks(Long memberId, Pageable pageable) {
 		Slice<Organization> organizations = getSlicedOrganizations(memberId, pageable);
-		List<AssignedTaskResponse> responses = organizations.stream()
-				.map(organization -> searchAssignedTasks(memberId, organization))
-				.toList();
+		List<TaskResponse> taskResponses = getTop5LatestTaskResponses(organizations);
+		List<AssignedTaskResponse> responses = assembleTasks(organizations, taskResponses);
 		return new PageImpl<>(responses, pageable, organizations.getSize());
 	}
 
@@ -57,27 +54,35 @@ public class TaskService {
 		taskRepository.deleteById(taskId);
 	}
 
-	private Slice<Organization> getSlicedOrganizations(Long memberId, Pageable pageable) {
-		return organizationMemberRepository.findOrganizationsByMemberId(memberId, pageable);
-	}
-
 	private Task findById(Long taskId) {
 		return taskRepository.findById(taskId)
 				.orElseThrow(() -> new NotFoundException(NOT_FOUND_TASK));
-	}
-
-	private AssignedTaskResponse searchAssignedTasks(Long memberId, Organization organization) {
-		List<TaskResponse> tasks = TaskResponse.fromTaskStatus(getTaskStatuses(memberId, organization.getId()));
-		return new AssignedTaskResponse(organization.getId(), organization.getName(), tasks);
-	}
-
-	private List<TaskStatus> getTaskStatuses(Long memberId, Long organizationId) {
-		return taskStatusRepository.findTop5ByOrganizationIdAndMemberId(organizationId, memberId);
 	}
 
 	private void validateAnnouncement(Long announcementId) {
 		if (!announcementRepository.existsById(announcementId)) {
 			throw new NotFoundException(NOT_FOUND_ANNOUNCEMENT);
 		}
+	}
+
+	private Slice<Organization> getSlicedOrganizations(Long memberId, Pageable pageable) {
+		return organizationMemberRepository.findOrganizationsByMemberId(memberId, pageable);
+	}
+
+	private List<TaskResponse> getTop5LatestTaskResponses(Slice<Organization> organizations) {
+		return organizations.stream()
+				.flatMap(org -> org.getAnnouncements().stream())
+				.flatMap(announcement -> announcement.getTasks().stream())
+				.sorted(Comparator.comparing(Task::getCreatedAt).reversed())
+				.limit(5)
+				.map(TaskResponse::from)
+				.toList();
+	}
+
+	private List<AssignedTaskResponse> assembleTasks(Slice<Organization> organizations,
+	                                                 List<TaskResponse> taskResponses) {
+		return organizations.stream()
+				.map(organization -> AssignedTaskResponse.from(organization, taskResponses))
+				.toList();
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/task/presentation/TaskApi.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/TaskApi.java
@@ -1,16 +1,19 @@
 package com.notitime.noffice.api.task.presentation;
 
-import com.notitime.noffice.auth.AuthMember;
-import com.notitime.noffice.global.web.NofficeResponse;
 import com.notitime.noffice.api.task.presentation.dto.request.TaskModifyRequest;
 import com.notitime.noffice.api.task.presentation.dto.response.AssignedTaskResponse;
 import com.notitime.noffice.api.task.presentation.dto.response.TaskModifyResponse;
+import com.notitime.noffice.auth.AuthMember;
+import com.notitime.noffice.global.web.NofficeResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 
 @Tag(name = "투두", description = "노티 하위 발급 투두 리스트 관련 API")
 interface TaskApi {
@@ -21,10 +24,12 @@ interface TaskApi {
 	})
 	NofficeResponse<TaskModifyResponse> modify(TaskModifyRequest taskModifyRequest);
 
-	@Operation(summary = "사용자 할당 투두 목록 조회", responses = {
+	@Operation(summary = "[인증] 사용자 할당 투두 목록 조회", responses = {
 			@ApiResponse(responseCode = "200", description = "사용자 할당 투두 조회 성공"),
 			@ApiResponse(responseCode = "404", description = "사용자 할당된 투두가 없습니다.")
 	})
 	NofficeResponse<Slice<AssignedTaskResponse>> getAssigned(@Parameter(hidden = true) @AuthMember final Long memberId,
+	                                                         @PageableDefault(size = 5)
+	                                                         @SortDefault(sort = "id", direction = Sort.Direction.DESC)
 	                                                         Pageable pageable);
 }

--- a/src/main/java/com/notitime/noffice/api/task/presentation/TaskController.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/TaskController.java
@@ -4,14 +4,17 @@ import static com.notitime.noffice.global.web.BusinessSuccessCode.GET_ASSIGNED_T
 import static com.notitime.noffice.global.web.BusinessSuccessCode.PATCH_TASK_MODIFY_SUCCESS;
 
 import com.notitime.noffice.api.task.business.TaskService;
-import com.notitime.noffice.auth.AuthMember;
-import com.notitime.noffice.global.web.NofficeResponse;
 import com.notitime.noffice.api.task.presentation.dto.request.TaskModifyRequest;
 import com.notitime.noffice.api.task.presentation.dto.response.AssignedTaskResponse;
 import com.notitime.noffice.api.task.presentation.dto.response.TaskModifyResponse;
+import com.notitime.noffice.auth.AuthMember;
+import com.notitime.noffice.global.web.NofficeResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,6 +35,8 @@ public class TaskController implements TaskApi {
 
 	@GetMapping("/assigned")
 	public NofficeResponse<Slice<AssignedTaskResponse>> getAssigned(@AuthMember final Long memberId,
+	                                                                @PageableDefault(size = 5)
+	                                                                @SortDefault(sort = "id", direction = Sort.Direction.DESC)
 	                                                                Pageable pageable) {
 		return NofficeResponse.success(GET_ASSIGNED_TASKS_SUCCESS,
 				taskService.getAssignedTasks(memberId, pageable));

--- a/src/main/java/com/notitime/noffice/api/task/presentation/dto/response/AssignedTaskResponse.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/dto/response/AssignedTaskResponse.java
@@ -1,5 +1,6 @@
 package com.notitime.noffice.api.task.presentation.dto.response;
 
+import com.notitime.noffice.domain.organization.model.Organization;
 import java.util.List;
 
 public record AssignedTaskResponse(
@@ -7,4 +8,7 @@ public record AssignedTaskResponse(
 		String organizationName,
 		List<TaskResponse> tasks
 ) {
+	public static AssignedTaskResponse from(Organization organization, List<TaskResponse> tasks) {
+		return new AssignedTaskResponse(organization.getId(), organization.getName(), tasks);
+	}
 }

--- a/src/main/java/com/notitime/noffice/api/task/presentation/dto/response/TaskResponse.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/dto/response/TaskResponse.java
@@ -2,7 +2,6 @@ package com.notitime.noffice.api.task.presentation.dto.response;
 
 import com.notitime.noffice.domain.task.model.Task;
 import com.notitime.noffice.domain.task.model.TaskStatus;
-import java.util.List;
 
 public record TaskResponse(Long id, Long announcementId, String content) {
 	public static TaskResponse from(Task task) {
@@ -12,11 +11,5 @@ public record TaskResponse(Long id, Long announcementId, String content) {
 	public static TaskResponse from(TaskStatus taskStatus) {
 		Task task = taskStatus.getTask();
 		return new TaskResponse(task.getId(), task.getAnnouncement().getId(), task.getContent());
-	}
-
-	public static List<TaskResponse> fromTaskStatus(List<TaskStatus> taskStatuses) {
-		return taskStatuses.stream()
-				.map(TaskResponse::from)
-				.toList();
 	}
 }

--- a/src/main/java/com/notitime/noffice/domain/FcmToken.java
+++ b/src/main/java/com/notitime/noffice/domain/FcmToken.java
@@ -28,14 +28,14 @@ public class FcmToken {
 	@JoinColumn(name = "member_id")
 	private Member member;
 
-	private String value;
+	private String token;
 
 	private String deviceId;
 
 	private LocalDateTime expiredAt;
 
-	public static FcmToken of(Member member, String value) {
-		return new FcmToken(null, member, value, null, null);
+	public static FcmToken of(Member member, String token) {
+		return new FcmToken(null, member, token, null, null);
 	}
 
 	private void setDeviceId(String deviceId) {

--- a/src/main/java/com/notitime/noffice/domain/announcement/model/Announcement.java
+++ b/src/main/java/com/notitime/noffice/domain/announcement/model/Announcement.java
@@ -134,6 +134,11 @@ public class Announcement extends BaseTimeEntity {
 		}
 	}
 
+	public void addTask(Task task) {
+		this.tasks.add(task);
+		task.setAnnouncement(this);
+	}
+
 	public void addNotification(Notification notification) {
 		this.notifications.add(notification);
 	}

--- a/src/main/java/com/notitime/noffice/domain/announcement/model/Announcement.java
+++ b/src/main/java/com/notitime/noffice/domain/announcement/model/Announcement.java
@@ -1,12 +1,12 @@
 package com.notitime.noffice.domain.announcement.model;
 
+import com.notitime.noffice.api.announcement.presentation.dto.request.AnnouncementUpdateRequest;
+import com.notitime.noffice.api.task.presentation.dto.request.TaskCreateRequest;
 import com.notitime.noffice.domain.BaseTimeEntity;
 import com.notitime.noffice.domain.member.model.Member;
 import com.notitime.noffice.domain.notification.model.Notification;
 import com.notitime.noffice.domain.organization.model.Organization;
 import com.notitime.noffice.domain.task.model.Task;
-import com.notitime.noffice.api.announcement.presentation.dto.request.AnnouncementUpdateRequest;
-import com.notitime.noffice.api.task.presentation.dto.request.TaskCreateRequest;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -127,7 +127,18 @@ public class Announcement extends BaseTimeEntity {
 		}
 	}
 
+	public void setOrganization(Organization organization) {
+		this.organization = organization;
+		if (!organization.getAnnouncements().contains(this)) {
+			organization.getAnnouncements().add(this);
+		}
+	}
+
 	public void addNotification(Notification notification) {
 		this.notifications.add(notification);
+	}
+
+	public void removeNotification(Notification notification) {
+		this.notifications.remove(notification);
 	}
 }

--- a/src/main/java/com/notitime/noffice/domain/fcmtoken/persistence/FcmTokenRepository.java
+++ b/src/main/java/com/notitime/noffice/domain/fcmtoken/persistence/FcmTokenRepository.java
@@ -6,9 +6,9 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
-	Optional<FcmToken> findByValue(String value);
+	Optional<FcmToken> findByToken(String token);
 
 	List<FcmToken> findByMemberId(Long memberId);
 
-	void deleteByValue(String value);
+	void deleteByToken(String value);
 }

--- a/src/main/java/com/notitime/noffice/domain/member/model/Member.java
+++ b/src/main/java/com/notitime/noffice/domain/member/model/Member.java
@@ -2,7 +2,9 @@ package com.notitime.noffice.domain.member.model;
 
 import com.notitime.noffice.domain.BaseTimeEntity;
 import com.notitime.noffice.domain.FcmToken;
+import com.notitime.noffice.domain.JoinStatus;
 import com.notitime.noffice.domain.SocialAuthProvider;
+import com.notitime.noffice.domain.organization.model.Organization;
 import com.notitime.noffice.domain.organization.model.OrganizationMember;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -71,5 +73,12 @@ public class Member extends BaseTimeEntity {
 
 	public void addFcmToken(FcmToken fcmToken) {
 		this.fcmTokens.add(fcmToken);
+	}
+
+	public List<Organization> getOrganizationsByStatus(JoinStatus joinStatus) {
+		return organizations.stream()
+				.filter(organizationMember -> organizationMember.getStatus() == joinStatus)
+				.map(OrganizationMember::getOrganization)
+				.toList();
 	}
 }

--- a/src/main/java/com/notitime/noffice/domain/organization/model/Organization.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/model/Organization.java
@@ -81,4 +81,11 @@ public class Organization extends BaseTimeEntity {
 	private void addLeader(Member leader) {
 		this.members.add(OrganizationMember.create(this, leader));
 	}
+
+	public void addAnnouncement(Announcement announcement) {
+		if (!this.announcements.contains(announcement)) {
+			announcements.add(announcement);
+		}
+		announcement.setOrganization(this);
+	}
 }

--- a/src/main/java/com/notitime/noffice/domain/organization/model/Organization.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/model/Organization.java
@@ -1,6 +1,7 @@
 package com.notitime.noffice.domain.organization.model;
 
 import com.notitime.noffice.domain.BaseTimeEntity;
+import com.notitime.noffice.domain.JoinStatus;
 import com.notitime.noffice.domain.announcement.model.Announcement;
 import com.notitime.noffice.domain.category.model.Category;
 import com.notitime.noffice.domain.member.model.Member;
@@ -87,5 +88,12 @@ public class Organization extends BaseTimeEntity {
 			announcements.add(announcement);
 		}
 		announcement.setOrganization(this);
+	}
+
+	public List<Member> getMembersByStatus(JoinStatus joinStatus) {
+		return members.stream()
+				.filter(organizationMember -> organizationMember.getStatus() == joinStatus)
+				.map(OrganizationMember::getMember)
+				.toList();
 	}
 }

--- a/src/main/java/com/notitime/noffice/domain/organization/model/OrganizationMember.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/model/OrganizationMember.java
@@ -47,10 +47,28 @@ public class OrganizationMember {
 	private Member member;
 
 	public static OrganizationMember join(Organization organization, Member member) {
-		return new OrganizationMember(null, PARTICIPANT, PENDING, organization, member);
+		OrganizationMember organizationMember = new OrganizationMember(null, PARTICIPANT, PENDING,
+				organization, member);
+		organizationMember.setOrganization(organization);
+		organizationMember.setMember(member);
+		return organizationMember;
 	}
 
 	public static OrganizationMember create(Organization organization, Member member) {
 		return new OrganizationMember(null, LEADER, ACTIVE, organization, member);
+	}
+
+	public void setOrganization(Organization organization) {
+		this.organization = organization;
+		if (!organization.getMembers().contains(this)) {
+			organization.getMembers().add(this);
+		}
+	}
+
+	public void setMember(Member member) {
+		this.member = member;
+		if (!member.getOrganizations().contains(this)) {
+			member.getOrganizations().add(this);
+		}
 	}
 }

--- a/src/main/java/com/notitime/noffice/domain/organization/model/OrganizationMember.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/model/OrganizationMember.java
@@ -5,6 +5,7 @@ import static com.notitime.noffice.domain.JoinStatus.PENDING;
 import static com.notitime.noffice.domain.OrganizationRole.LEADER;
 import static com.notitime.noffice.domain.OrganizationRole.PARTICIPANT;
 
+import com.notitime.noffice.domain.BaseTimeEntity;
 import com.notitime.noffice.domain.JoinStatus;
 import com.notitime.noffice.domain.OrganizationRole;
 import com.notitime.noffice.domain.member.model.Member;
@@ -26,7 +27,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-public class OrganizationMember {
+public class OrganizationMember extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/notitime/noffice/domain/task/model/Task.java
+++ b/src/main/java/com/notitime/noffice/domain/task/model/Task.java
@@ -36,11 +36,20 @@ public class Task extends BaseTimeEntity {
 	}
 
 	public static Task create(String content, Announcement announcement) {
-		return new Task(content, announcement);
+		Task task = new Task(content, announcement);
+		task.setAnnouncement(announcement);
+		return task;
 	}
 
 	public Task modify(String content) {
 		this.content = content;
 		return this;
+	}
+
+	public void setAnnouncement(Announcement announcement) {
+		this.announcement = announcement;
+		if (!announcement.getTasks().contains(this)) {
+			announcement.getTasks().add(this);
+		}
 	}
 }

--- a/src/main/java/com/notitime/noffice/domain/task/persistence/TaskStatusRepository.java
+++ b/src/main/java/com/notitime/noffice/domain/task/persistence/TaskStatusRepository.java
@@ -1,16 +1,7 @@
 package com.notitime.noffice.domain.task.persistence;
 
 import com.notitime.noffice.domain.task.model.TaskStatus;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface TaskStatusRepository extends JpaRepository<TaskStatus, Long> {
-	@Query("SELECT ts FROM TaskStatus ts " +
-			"JOIN FETCH ts.task t " +
-			"WHERE ts.member.id = :memberId " +
-			"AND ts.isChecked = false " +
-			"AND t.announcement.organization.id = :organizationId " +
-			"ORDER BY t.createdAt DESC")
-	List<TaskStatus> findTop5ByOrganizationIdAndMemberId(Long organizationId, Long memberId);
 }

--- a/src/main/java/com/notitime/noffice/external/firebase/FcmService.java
+++ b/src/main/java/com/notitime/noffice/external/firebase/FcmService.java
@@ -132,7 +132,7 @@ public class FcmService {
 
 	private List<String> getMemberTokens(Long memberId) {
 		return fcmTokenRepository.findByMemberId(memberId).stream()
-				.map(FcmToken::getValue)
+				.map(FcmToken::getToken)
 				.toList();
 	}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,14 +4,14 @@ spring:
       local: "local, key"
       dev: "develop, datasource, key"
       prod: "production, datasource, key"
-    active: dev
+    active: local
 
   jackson:
     property-naming-strategy: LOWER_CAMEL_CASE
 
   cache:
     type: simple
-    
+
 springdoc:
   swagger-ui:
     path: /api-docs


### PR DESCRIPTION
## 🚀 Related Issue

close: #124 

## 📌 Tasks

- 상호 조회가 필요한 `조직`, `멤버`, `공지` 간 연관관계 편의 메소드 정의 (각각 루트 및 연결 엔티티)

## 📝 Details

- 조직별 최신 생성된 5개 투두만 조회하도록 변경
```java
	public Slice<AssignedTaskResponse> getAssignedTasks(Long memberId, Pageable pageable) {
		Slice<Organization> organizations = getSlicedOrganizations(memberId, pageable);
		List<TaskResponse> taskResponses = getTop5LatestTaskResponses(organizations);
		List<AssignedTaskResponse> responses = assembleTasks(organizations, taskResponses);
		return new PageImpl<>(responses, pageable, organizations.getSize());
	}
```

## 📚 Remarks
- 개선 이전
```java
        public interface TaskStatusRepository extends JpaRepository<TaskStatus, Long> {
	        @Query("SELECT ts FROM TaskStatus ts " +
			        "JOIN FETCH ts.task t " +
			        "WHERE ts.member.id = :memberId " +
			        "AND ts.isChecked = false " +
			        "AND t.announcement.organization.id = :organizationId " +
			        "ORDER BY t.createdAt DESC")
	        List<TaskStatus> findTop5ByOrganizationIdAndMemberId(Long organizationId, Long memberId);
        }
	public Slice<AssignedTaskResponse> getAssignedTasks(Long memberId, Pageable pageable) {
		Slice<Organization> organizations = getSlicedOrganizations(memberId, pageable);
		List<AssignedTaskResponse> responses = organizations.stream()
				.map(organization -> searchAssignedTasks(memberId, organization))
				.toList();
		return new PageImpl<>(responses, pageable, organizations.getSize());
	}
	private AssignedTaskResponse searchAssignedTasks(Long memberId, Organization organization) {
		List<TaskResponse> tasks = TaskResponse.fromTaskStatus(getTaskStatuses(memberId, organization.getId()));
		return new AssignedTaskResponse(organization.getId(), organization.getName(), tasks);
	}

	private List<TaskStatus> getTaskStatuses(Long memberId, Long organizationId) {
		return taskStatusRepository.findTop5ByOrganizationIdAndMemberId(organizationId, memberId);
	}
```
