### PR TITLE
✨ [Feat] 도메인 이미지 추가, 삭제 기능

### DIFF
--- a/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
@@ -137,4 +137,11 @@ public class AnnouncementService {
 				.orElseThrow(() -> new NotFoundException(NOT_FOUND_ANNOUNCEMENT))
 				.getOrganization().getId();
 	}
+
+	public void modifyCover(Long memberId, Long announcementId, String coverImageUrl) {
+		Announcement announcement = announcementRepository.findById(announcementId)
+				.orElseThrow(() -> new NotFoundException(NOT_FOUND_ANNOUNCEMENT));
+		announcement.modifyCover(coverImageUrl);
+		announcementRepository.save(announcement);
+	}
 }

--- a/src/main/java/com/notitime/noffice/api/announcement/presentation/AnnouncementApi.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/presentation/AnnouncementApi.java
@@ -1,17 +1,19 @@
 package com.notitime.noffice.api.announcement.presentation;
 
-import com.notitime.noffice.auth.AuthMember;
-import com.notitime.noffice.external.firebase.FCMCreateResponse;
-import com.notitime.noffice.global.web.NofficeResponse;
 import com.notitime.noffice.api.announcement.presentation.dto.request.AnnouncementCreateRequest;
 import com.notitime.noffice.api.announcement.presentation.dto.request.AnnouncementUpdateRequest;
 import com.notitime.noffice.api.announcement.presentation.dto.response.AnnouncementResponse;
 import com.notitime.noffice.api.announcement.presentation.dto.response.AnnouncementResponses;
 import com.notitime.noffice.api.announcement.presentation.dto.response.ReadStatusResponse;
 import com.notitime.noffice.api.task.presentation.dto.response.TaskResponses;
+import com.notitime.noffice.auth.AuthMember;
+import com.notitime.noffice.external.firebase.FCMCreateResponse;
+import com.notitime.noffice.global.web.NofficeResponse;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -89,4 +91,13 @@ interface AnnouncementApi {
 	})
 	NofficeResponse<ReadStatusResponse> getUnReadMembers(@Parameter(hidden = true) @AuthMember final Long memberId,
 	                                                     @PathVariable final Long announcementId);
+
+	@Operation(summary = "공지 커버 이미지 수정", description = "공지에 설정된 이미지를 변경합니다. 이미지는 선택 가능한 이미지 내에서 설정 가능합니다.", responses = {
+			@ApiResponse(responseCode = "204", description = "공지 커버 이미지 수정 성공"),
+			@ApiResponse(responseCode = "403", description = "요청을 수행할 수 있는 권한이 없습니다.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "404", description = "선택 가능한 이미지 주소가 아닙니다.", content = @Content(schema = @Schema(implementation = NofficeResponse.class)))
+	})
+	NofficeResponse<Void> modifyCover(@Parameter(hidden = true) @AuthMember final Long memberId,
+	                                  @PathVariable final Long announcementId,
+	                                  @RequestBody final String coverImageUrl);
 }

--- a/src/main/java/com/notitime/noffice/api/announcement/presentation/AnnouncementController.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/presentation/AnnouncementController.java
@@ -7,25 +7,27 @@ import static com.notitime.noffice.global.web.BusinessSuccessCode.GET_ANNOUNCEME
 import static com.notitime.noffice.global.web.BusinessSuccessCode.GET_READ_MEMBERS_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.GET_TASKS_BY_ANNOUNCEMENT_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.GET_UNREAD_MEMBERS_SUCCESS;
+import static com.notitime.noffice.global.web.BusinessSuccessCode.PATCH_MODIFY_COVER_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.POST_ANNOUNCEMENT_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.PUT_ANNOUNCEMENT_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.SEND_UNREADER_REMIND_SUCCSS;
 
 import com.notitime.noffice.api.announcement.business.AnnouncementService;
-import com.notitime.noffice.api.task.business.TaskService;
-import com.notitime.noffice.auth.AuthMember;
-import com.notitime.noffice.external.firebase.FCMCreateResponse;
-import com.notitime.noffice.external.firebase.FcmService;
-import com.notitime.noffice.global.web.NofficeResponse;
 import com.notitime.noffice.api.announcement.presentation.dto.request.AnnouncementCreateRequest;
 import com.notitime.noffice.api.announcement.presentation.dto.request.AnnouncementUpdateRequest;
 import com.notitime.noffice.api.announcement.presentation.dto.response.AnnouncementResponse;
 import com.notitime.noffice.api.announcement.presentation.dto.response.AnnouncementResponses;
 import com.notitime.noffice.api.announcement.presentation.dto.response.ReadStatusResponse;
+import com.notitime.noffice.api.task.business.TaskService;
 import com.notitime.noffice.api.task.presentation.dto.response.TaskResponses;
+import com.notitime.noffice.auth.AuthMember;
+import com.notitime.noffice.external.firebase.FCMCreateResponse;
+import com.notitime.noffice.external.firebase.FcmService;
+import com.notitime.noffice.global.web.NofficeResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -108,5 +110,12 @@ public class AnnouncementController implements AnnouncementApi {
 	                                                            @PathVariable final Long announcementId) {
 		return NofficeResponse.success(GET_UNREAD_MEMBERS_SUCCESS,
 				announcementService.getUnreadMembers(memberId, announcementId));
+	}
+
+	@PatchMapping("/{announcementId}/cover")
+	public NofficeResponse<Void> modifyCover(@AuthMember final Long memberId, @PathVariable final Long announcementId,
+	                                         @RequestBody final String coverImageUrl) {
+		announcementService.modifyCover(memberId, announcementId, coverImageUrl);
+		return NofficeResponse.success(PATCH_MODIFY_COVER_SUCCESS);
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/member/business/MemberService.java
+++ b/src/main/java/com/notitime/noffice/api/member/business/MemberService.java
@@ -1,10 +1,10 @@
 package com.notitime.noffice.api.member.business;
 
+import com.notitime.noffice.api.member.presentation.dto.response.MemberResponse;
 import com.notitime.noffice.domain.member.model.Member;
 import com.notitime.noffice.domain.member.persistence.MemberRepository;
 import com.notitime.noffice.global.exception.NotFoundException;
 import com.notitime.noffice.global.web.BusinessErrorCode;
-import com.notitime.noffice.api.member.presentation.dto.response.MemberResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,5 +23,11 @@ public class MemberService {
 	private Member getMemberEntity(Long memberId) {
 		return memberRepository.findById(memberId)
 				.orElseThrow(() -> new NotFoundException(BusinessErrorCode.NOT_FOUND_MEMBER));
+	}
+
+	public void deleteProfileImage(Long memberId) {
+		Member member = getMemberEntity(memberId);
+		member.deleteProfileImage();
+		memberRepository.save(member);
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/member/presentation/MemberApi.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/MemberApi.java
@@ -1,11 +1,11 @@
 package com.notitime.noffice.api.member.presentation;
 
-import com.notitime.noffice.auth.AuthMember;
-import com.notitime.noffice.global.web.NofficeResponse;
 import com.notitime.noffice.api.auth.presentation.dto.request.SocialAuthRequest;
-import com.notitime.noffice.api.member.presentation.dto.response.MemberResponse;
 import com.notitime.noffice.api.auth.presentation.dto.response.SocialAuthResponse;
 import com.notitime.noffice.api.auth.presentation.dto.response.TokenResponse;
+import com.notitime.noffice.api.member.presentation.dto.response.MemberResponse;
+import com.notitime.noffice.auth.AuthMember;
+import com.notitime.noffice.global.web.NofficeResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -29,4 +29,12 @@ interface MemberApi {
 			@ApiResponse(responseCode = "200", description = "회원 정보 조회에 성공하였습니다.")
 	})
 	NofficeResponse<MemberResponse> getById(@Parameter(hidden = true) @AuthMember final Long memberId);
+
+	@Operation(summary = "[인증] 회원 프로필 이미지 삭제", description = "회원의 프로필 이미지를 기본값(null)으로 되돌립니다.", responses = {
+			// no content
+			@ApiResponse(responseCode = "204", description = "회원 프로필 이미지 삭제에 성공하였습니다."),
+			@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다."),
+			@ApiResponse(responseCode = "403", description = "해당 회원이 아니므로 권한을 부여하지 않습니다.")
+	})
+	NofficeResponse<Void> deleteProfileImage(@Parameter(hidden = true) @AuthMember final Long memberId);
 }

--- a/src/main/java/com/notitime/noffice/api/member/presentation/MemberController.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/MemberController.java
@@ -1,18 +1,21 @@
 package com.notitime.noffice.api.member.presentation;
 
+import static com.notitime.noffice.global.web.BusinessSuccessCode.DELETE_PROFILE_IMAGE_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.GET_MEMBER_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.POST_LOGIN_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.POST_REISSUE_SUCCESS;
 
 import com.notitime.noffice.api.auth.business.AuthService;
-import com.notitime.noffice.api.member.business.MemberService;
-import com.notitime.noffice.auth.AuthMember;
-import com.notitime.noffice.global.web.NofficeResponse;
 import com.notitime.noffice.api.auth.presentation.dto.request.SocialAuthRequest;
-import com.notitime.noffice.api.member.presentation.dto.response.MemberResponse;
 import com.notitime.noffice.api.auth.presentation.dto.response.SocialAuthResponse;
 import com.notitime.noffice.api.auth.presentation.dto.response.TokenResponse;
+import com.notitime.noffice.api.member.business.MemberService;
+import com.notitime.noffice.api.member.presentation.dto.response.MemberResponse;
+import com.notitime.noffice.auth.AuthMember;
+import com.notitime.noffice.global.web.NofficeResponse;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,5 +44,11 @@ public class MemberController implements MemberApi {
 	@GetMapping
 	public NofficeResponse<MemberResponse> getById(@AuthMember final Long memberId) {
 		return NofficeResponse.success(GET_MEMBER_SUCCESS, memberService.getMember(memberId));
+	}
+
+	@DeleteMapping("/profile-image")
+	public NofficeResponse<Void> deleteProfileImage(@Parameter(hidden = true) @AuthMember final Long memberId) {
+		memberService.deleteProfileImage(memberId);
+		return NofficeResponse.success(DELETE_PROFILE_IMAGE_SUCCESS);
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/organization/business/OrganizationService.java
+++ b/src/main/java/com/notitime/noffice/api/organization/business/OrganizationService.java
@@ -129,6 +129,12 @@ public class OrganizationService {
 				imageRetrievalContext.retrieve(organizationId));
 	}
 
+	public void deleteProfileImage(Long organizationId) {
+		Organization organization = getOrganizationEntity(organizationId);
+		organization.deleteProfileImage();
+		organizationRepository.save(organization);
+	}
+
 	private Member getMemberEntity(Long memberId) {
 		return memberRepository.findById(memberId)
 				.orElseThrow(() -> new NotFoundException(NOT_FOUND_MEMBER));

--- a/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationApi.java
+++ b/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationApi.java
@@ -117,4 +117,13 @@ interface OrganizationApi {
 	NofficeResponse<OrganizationImageResponse> getSelectableCover(
 			@Parameter(hidden = true) @AuthMember final Long memberId,
 			@PathVariable final Long organizationId);
+
+	@Operation(summary = "[인증] 조직 프로필 이미지 삭제", description = "조직 프로필 이미지를 삭제합니다.", responses = {
+			@ApiResponse(responseCode = "204", description = "프로필 이미지 삭제 성공"),
+			@ApiResponse(responseCode = "400", description = "프로필 이미지 삭제 실패", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "403", description = "요청을 수행할 수 있는 권한이 없습니다.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "500", description = "서버 내부 에러 발생", content = @Content(schema = @Schema(implementation = NofficeResponse.class)))
+	})
+	NofficeResponse<Void> deleteProfileImage(@Parameter(hidden = true) @AuthMember final Long memberId,
+	                                         @PathVariable Long organizationId);
 }

--- a/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationController.java
+++ b/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationController.java
@@ -1,6 +1,7 @@
 package com.notitime.noffice.api.organization.presentation;
 
 import static com.notitime.noffice.global.web.BusinessSuccessCode.CREATE_ORGANIZATION_SUCCESS;
+import static com.notitime.noffice.global.web.BusinessSuccessCode.DELETE_PROFILE_IMAGE_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.GET_JOINED_ORGANIZATIONS_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.GET_ORGANIZATION_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.GET_PENDING_MEMBERS_SUCCESS;
@@ -13,26 +14,27 @@ import static com.notitime.noffice.global.web.BusinessSuccessCode.POST_JOIN_ORGA
 import static com.notitime.noffice.global.web.BusinessSuccessCode.PUT_CATEGORIES_SUCCESS;
 
 import com.notitime.noffice.api.announcement.business.AnnouncementService;
+import com.notitime.noffice.api.announcement.presentation.dto.response.AnnouncementCoverResponse;
+import com.notitime.noffice.api.category.presentation.dto.request.CategoryModifyRequest;
+import com.notitime.noffice.api.category.presentation.dto.response.CategoryModifyResponse;
+import com.notitime.noffice.api.member.presentation.dto.response.MemberInfoResponse;
+import com.notitime.noffice.api.organization.business.OrganizationService;
+import com.notitime.noffice.api.organization.presentation.dto.request.ChangeRoleRequest;
+import com.notitime.noffice.api.organization.presentation.dto.request.OrganizationCreateRequest;
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationCreateResponse;
+import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationImageResponse;
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationInfoResponse;
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationJoinResponse;
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationResponse;
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationSignupResponse;
-import com.notitime.noffice.api.organization.business.OrganizationService;
-import com.notitime.noffice.api.organization.presentation.dto.request.ChangeRoleRequest;
-import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationImageResponse;
 import com.notitime.noffice.auth.AuthMember;
 import com.notitime.noffice.global.web.NofficeResponse;
-import com.notitime.noffice.api.category.presentation.dto.request.CategoryModifyRequest;
-import com.notitime.noffice.api.organization.presentation.dto.request.OrganizationCreateRequest;
-import com.notitime.noffice.api.announcement.presentation.dto.response.AnnouncementCoverResponse;
-import com.notitime.noffice.api.category.presentation.dto.response.CategoryModifyResponse;
-import com.notitime.noffice.api.member.presentation.dto.response.MemberInfoResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -125,5 +127,12 @@ public class OrganizationController implements OrganizationApi {
 	                                                                     @PathVariable final Long organizationId) {
 		return NofficeResponse.success(GET_SELECTABLE_COVER_SUCCESS,
 				organizationService.getSelectableCover(memberId, organizationId));
+	}
+
+	@DeleteMapping("/{organizationId}/profile-image")
+	public NofficeResponse<Void> deleteProfileImage(@AuthMember final Long memberId,
+	                                                @PathVariable Long organizationId) {
+		organizationService.deleteProfileImage(organizationId);
+		return NofficeResponse.success(DELETE_PROFILE_IMAGE_SUCCESS);
 	}
 }

--- a/src/main/java/com/notitime/noffice/domain/announcement/model/Announcement.java
+++ b/src/main/java/com/notitime/noffice/domain/announcement/model/Announcement.java
@@ -146,4 +146,8 @@ public class Announcement extends BaseTimeEntity {
 	public void removeNotification(Notification notification) {
 		this.notifications.remove(notification);
 	}
+
+	public void modifyCover(String profileImageUrl) {
+		this.profileImageUrl = profileImageUrl;
+	}
 }

--- a/src/main/java/com/notitime/noffice/domain/member/model/Member.java
+++ b/src/main/java/com/notitime/noffice/domain/member/model/Member.java
@@ -81,4 +81,8 @@ public class Member extends BaseTimeEntity {
 				.map(OrganizationMember::getOrganization)
 				.toList();
 	}
+
+	public void deleteProfileImage() {
+		this.profileImage = null;
+	}
 }

--- a/src/main/java/com/notitime/noffice/domain/organization/model/Organization.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/model/Organization.java
@@ -96,4 +96,8 @@ public class Organization extends BaseTimeEntity {
 				.map(OrganizationMember::getMember)
 				.toList();
 	}
+
+	public void deleteProfileImage() {
+		this.profileImage = null;
+	}
 }

--- a/src/main/java/com/notitime/noffice/global/web/BusinessSuccessCode.java
+++ b/src/main/java/com/notitime/noffice/global/web/BusinessSuccessCode.java
@@ -51,6 +51,7 @@ public enum BusinessSuccessCode implements SuccessCode {
 	DELETE_NOTIFICATION_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2073", "알림 삭제 성공"),
 	DELETE_TASK_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2093", "투두 삭제 성공"),
 	PATCH_REGISTER_MEMBER_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2081", "조직 가입 승인 성공"),
+	DELETE_PROFILE_IMAGE_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2402", "프로필 이미지 삭제에 성공하였습니다."),
 
 	// RESET CONTENT (2500 ~ 2599)
 	RESET_CONTENT(HttpStatus.RESET_CONTENT, "NOF-205", "리소스가 갱신되었습니다. - 205");

--- a/src/main/java/com/notitime/noffice/global/web/BusinessSuccessCode.java
+++ b/src/main/java/com/notitime/noffice/global/web/BusinessSuccessCode.java
@@ -51,7 +51,8 @@ public enum BusinessSuccessCode implements SuccessCode {
 	DELETE_NOTIFICATION_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2073", "알림 삭제 성공"),
 	DELETE_TASK_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2093", "투두 삭제 성공"),
 	PATCH_REGISTER_MEMBER_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2081", "조직 가입 승인 성공"),
-	DELETE_PROFILE_IMAGE_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2402", "프로필 이미지 삭제에 성공하였습니다."),
+	DELETE_PROFILE_IMAGE_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2402", "프로필 이미지 삭제 성공"),
+	PATCH_MODIFY_COVER_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2403", "공지 커버 이미지 수정 성공"),
 
 	// RESET CONTENT (2500 ~ 2599)
 	RESET_CONTENT(HttpStatus.RESET_CONTENT, "NOF-205", "리소스가 갱신되었습니다. - 205");


### PR DESCRIPTION
## 🚀 Related Issue

close: #127 

## 📌 Tasks

- Core domain (`Member`, `Organization`, `Announcement`) 내 image 수정 기능

## 📝 Details

> 상세 체크 리스트를 작성해주세요.

- [ ] 이미지 수정 -> re-send Presigned URL PUT request로 해결
- [ ] 이미지 삭제
- [ ] 사용자, 조직 프로필의 경우 기본 이미지로 변환 -> `DELETE` | `{EntityIdentifier}/image`
- [ ] 공지 커버의 경우 이미지 삭제 시 null 설정 -> `DELETE` | `{EntityIdentifier}/cover`

## 📚 Remarks

- 
- 