### PR TITLE
:ambulance: [Hotfix] redis dependency 비활성화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     // Redis
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+//    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // AWS
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'


### PR DESCRIPTION
## 🚀 Related Issue

close: #

## 📌 Tasks

- redis dependency 비활성화
- 미설정 세팅으로 인한 ec2 memory OutOfBounds 발생

## 📝 Details

- 

## 📚 Remarks

- 
- 