### PR TITLE
♻️ [Refactor] 공지 미열람자는 전체 멤버의 열람자를 제외함과 동일하다

### DIFF
--- a/src/main/java/com/notitime/noffice/api/announcement/business/ReadStatusRecoder.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/business/ReadStatusRecoder.java
@@ -1,11 +1,16 @@
 package com.notitime.noffice.api.announcement.business;
 
+import static com.notitime.noffice.global.web.BusinessErrorCode.NOT_FOUND_ORGANIZATION;
+
 import com.notitime.noffice.api.organization.business.RoleVerifier;
+import com.notitime.noffice.domain.JoinStatus;
 import com.notitime.noffice.domain.announcement.model.Announcement;
 import com.notitime.noffice.domain.announcement.model.AnnouncementReadStatus;
 import com.notitime.noffice.domain.announcement.persistence.AnnouncementReadStatusRepository;
 import com.notitime.noffice.domain.announcement.persistence.AnnouncementRepository;
 import com.notitime.noffice.domain.member.model.Member;
+import com.notitime.noffice.domain.organization.model.Organization;
+import com.notitime.noffice.global.exception.NotFoundException;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -35,7 +40,13 @@ public class ReadStatusRecoder {
 	}
 
 	public List<Member> findUnReadMembers(Long announcementId) {
-		return announcementReadStatusRepository.findUnReadMembers(announcementId);
+		Organization organization = announcementRepository.findById(announcementId)
+				.orElseThrow(() -> new NotFoundException(NOT_FOUND_ORGANIZATION))
+				.getOrganization();
+		List<Member> allMembers = organization.getMembersByStatus(JoinStatus.ACTIVE);
+		List<Member> readMembers = findReadMembers(announcementId);
+		allMembers.removeAll(readMembers);
+		return allMembers;
 	}
 
 	public Long countReader(Long announcementId) {


### PR DESCRIPTION
## 🚀 Related Issue

close: #

## 📌 Tasks

- 미열람자를 계산할 때, 계산 대상은 `{전체 독자} - {열람자}`로, 미열람 상태 쿼리를 조회하지 않을 수 있다.

## 📝 Details

- 

## 📚 Remarks

- [RDS Hikari pool logger 구성](https://github.com/Team-Notitime/NOFFICE-SERVER/commit/55aa1c75a53467849dc045ae8c270009af4564b5)
- connection 관리 로그 수집을 위해 추가