### PR TITLE
✨ [Feat] 사용자 투두 체크리스트 기록 기능

### DIFF
--- a/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
@@ -13,6 +13,7 @@ import com.notitime.noffice.api.announcement.presentation.dto.response.ReadStatu
 import com.notitime.noffice.api.member.presentation.dto.response.MemberInfoResponse;
 import com.notitime.noffice.api.notification.business.NotificationService;
 import com.notitime.noffice.api.organization.business.RoleVerifier;
+import com.notitime.noffice.api.task.business.TaskStatusManager;
 import com.notitime.noffice.domain.announcement.model.Announcement;
 import com.notitime.noffice.domain.announcement.persistence.AnnouncementRepository;
 import com.notitime.noffice.domain.member.model.Member;
@@ -40,6 +41,7 @@ public class AnnouncementService {
 	private final RoleVerifier roleVerifier;
 	private final ReadStatusRecoder readStatusRecoder;
 	private final FcmService fcmService;
+	private final TaskStatusManager taskStatusManager;
 
 	public AnnouncementResponse read(Long memberId, Long announcementId) {
 		roleVerifier.verifyJoinedMember(memberId, getOrganizationId(announcementId));
@@ -114,6 +116,7 @@ public class AnnouncementService {
 		);
 		announcement.withTasks(request.tasks());
 		announcementRepository.save(announcement);
+		taskStatusManager.assignTasks(organization, announcement);
 		organization.addAnnouncement(announcement);
 		return announcement;
 	}

--- a/src/main/java/com/notitime/noffice/api/task/business/TaskService.java
+++ b/src/main/java/com/notitime/noffice/api/task/business/TaskService.java
@@ -82,8 +82,8 @@ public class TaskService {
 						List.of(memberId)
 				).stream()
 				.filter(ts -> !ts.getIsChecked())
-				.limit(5)
 				.sorted(Comparator.comparing(TaskStatus::getCreatedAt).reversed())
+				.limit(5)
 				.toList();
 		List<TaskResponse> assembled = assignedTasks.stream()
 				.map(ts -> TaskResponse.from(ts.getTask(), ts.getIsChecked()))

--- a/src/main/java/com/notitime/noffice/api/task/business/TaskService.java
+++ b/src/main/java/com/notitime/noffice/api/task/business/TaskService.java
@@ -4,6 +4,7 @@ import static com.notitime.noffice.global.web.BusinessErrorCode.NOT_FOUND_ANNOUN
 import static com.notitime.noffice.global.web.BusinessErrorCode.NOT_FOUND_TASK;
 
 import com.notitime.noffice.api.task.presentation.dto.request.TaskModifyRequest;
+import com.notitime.noffice.api.task.presentation.dto.request.TaskStatusUpdateRequest;
 import com.notitime.noffice.api.task.presentation.dto.response.AssignedTaskResponse;
 import com.notitime.noffice.api.task.presentation.dto.response.TaskModifyResponse;
 import com.notitime.noffice.api.task.presentation.dto.response.TaskResponse;
@@ -94,5 +95,12 @@ public class TaskService {
 		return organization.getAnnouncements().stream()
 				.flatMap(announcement -> announcement.getTasks().stream())
 				.toList();
+	}
+
+	public void updateTaskStatus(Long memberId, TaskStatusUpdateRequest request) {
+		request.taskIds().forEach(taskId -> {
+			TaskStatus taskStatus = taskStatusRepository.findByTaskIdAndMemberId(taskId, memberId);
+			taskStatus.setChecked(true);
+		});
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/task/business/TaskService.java
+++ b/src/main/java/com/notitime/noffice/api/task/business/TaskService.java
@@ -98,9 +98,14 @@ public class TaskService {
 	}
 
 	public void updateTaskStatus(Long memberId, TaskStatusUpdateRequest request) {
-		request.taskIds().forEach(taskId -> {
-			TaskStatus taskStatus = taskStatusRepository.findByTaskIdAndMemberId(taskId, memberId);
-			taskStatus.setChecked(true);
-		});
+		List<Long> checkFailedTaskIds = request.taskIds()
+				.stream()
+				.filter(taskId -> {
+					TaskStatus taskStatus = taskStatusRepository.findByTaskIdAndMemberId(taskId, memberId);
+					return taskStatus == null || taskStatus.getIsChecked();
+				}).toList();
+		if (!checkFailedTaskIds.isEmpty()) {
+			throw new NotFoundException("투두가 존재하지 않거나 이미 완료된 투두입니다. : " + checkFailedTaskIds, NOT_FOUND_TASK);
+		}
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/task/business/TaskStatusManager.java
+++ b/src/main/java/com/notitime/noffice/api/task/business/TaskStatusManager.java
@@ -1,0 +1,43 @@
+package com.notitime.noffice.api.task.business;
+
+import com.notitime.noffice.domain.announcement.model.Announcement;
+import com.notitime.noffice.domain.member.model.Member;
+import com.notitime.noffice.domain.organization.model.Organization;
+import com.notitime.noffice.domain.organization.persistence.OrganizationMemberRepository;
+import com.notitime.noffice.domain.organization.persistence.OrganizationRepository;
+import com.notitime.noffice.domain.task.model.TaskStatus;
+import com.notitime.noffice.domain.task.persistence.TaskRepository;
+import com.notitime.noffice.domain.task.persistence.TaskStatusRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TaskStatusManager {
+	private final TaskRepository taskRepository;
+	private final TaskStatusRepository taskStatusRepository;
+	private final OrganizationRepository organizationRepository;
+	private final OrganizationMemberRepository organizationMemberRepository;
+
+	public void assignTasks(Organization organization, Announcement announcement) {
+		List<Member> members = getParticipants(organization.getId());
+		List<TaskStatus> taskStatuses = members.stream()
+				.flatMap(member -> announcement.getTasks().stream()
+						.map(task -> TaskStatus.create(task, member)))
+				.toList();
+		taskStatusRepository.saveAll(taskStatuses);
+	}
+
+	private List<Member> getParticipants(Long organizationId) {
+		return organizationMemberRepository.findParticipantsByOrganizationId(organizationId);
+	}
+
+//	public void recordTaskStatus(Long memberId, Long taskId) {
+//		TaskStatus taskStatus = taskStatusRepository.findByTaskIdAndMemberId(taskId, memberId)
+//				.orElseThrow(() -> new NotFoundException(NOT_FOUND_TASK_STATUS));
+//		taskStatus.check();
+//	}
+}

--- a/src/main/java/com/notitime/noffice/api/task/business/TaskStatusManager.java
+++ b/src/main/java/com/notitime/noffice/api/task/business/TaskStatusManager.java
@@ -24,11 +24,17 @@ public class TaskStatusManager {
 
 	public void assignTasks(Organization organization, Announcement announcement) {
 		List<Member> members = getParticipants(organization.getId());
+		List<Member> leaders = getLeaders(organization.getId());
+		members.addAll(leaders);
 		List<TaskStatus> taskStatuses = members.stream()
 				.flatMap(member -> announcement.getTasks().stream()
 						.map(task -> TaskStatus.create(task, member)))
 				.toList();
 		taskStatusRepository.saveAll(taskStatuses);
+	}
+
+	private List<Member> getLeaders(Long organizationId) {
+		return organizationMemberRepository.findLeadersByOrganizationId(organizationId);
 	}
 
 	private List<Member> getParticipants(Long organizationId) {

--- a/src/main/java/com/notitime/noffice/api/task/presentation/TaskApi.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/TaskApi.java
@@ -45,7 +45,7 @@ interface TaskApi {
 			@ApiResponse(responseCode = "204", description = "투두 상태 업데이트 성공", content = @Content),
 			@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다. 토큰을 확인해주세요.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
 			@ApiResponse(responseCode = "403", description = "요청을 수행할 수 있는 권한이 없습니다.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
-			@ApiResponse(responseCode = "404", description = "투두가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "404", description = "(변경 가능한 투두는 체크완료 처리됩니다.) 투두가 존재하지 않거나 이미 완료된 투두입니다. : [2, 3]", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
 			@ApiResponse(responseCode = "500", description = "서버 내부 에러 발생", content = @Content(schema = @Schema(implementation = NofficeResponse.class)))
 	})
 	NofficeResponse<Void> updateTaskStatus(@Parameter(hidden = true) @AuthMember final Long memberId,

--- a/src/main/java/com/notitime/noffice/api/task/presentation/TaskApi.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/TaskApi.java
@@ -20,7 +20,7 @@ import org.springframework.data.web.SortDefault;
 @Tag(name = "투두", description = "노티 하위 발급 투두 리스트 관련 API")
 interface TaskApi {
 
-	@Operation(summary = "투두 수정", responses = {
+	@Operation(summary = "조직 내 투두 상세 내용 수정", description = "등록된 투두 내용을 수정합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "투두 수정 성공"),
 			@ApiResponse(responseCode = "400", description = "투두 수정 실패", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
 			@ApiResponse(responseCode = "403", description = "요청을 수행할 수 있는 권한이 없습니다.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),

--- a/src/main/java/com/notitime/noffice/api/task/presentation/TaskApi.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/TaskApi.java
@@ -1,7 +1,7 @@
 package com.notitime.noffice.api.task.presentation;
 
 import com.notitime.noffice.api.task.presentation.dto.request.TaskModifyRequest;
-import com.notitime.noffice.api.task.presentation.dto.request.TaskStatusUpdateRequest;
+import com.notitime.noffice.api.task.presentation.dto.request.TaskStatusUpdateRequests;
 import com.notitime.noffice.api.task.presentation.dto.response.AssignedTaskResponse;
 import com.notitime.noffice.api.task.presentation.dto.response.TaskModifyResponse;
 import com.notitime.noffice.auth.AuthMember;
@@ -49,5 +49,5 @@ interface TaskApi {
 			@ApiResponse(responseCode = "500", description = "서버 내부 에러 발생", content = @Content(schema = @Schema(implementation = NofficeResponse.class)))
 	})
 	NofficeResponse<Void> updateTaskStatus(@Parameter(hidden = true) @AuthMember final Long memberId,
-	                                       TaskStatusUpdateRequest request);
+	                                       TaskStatusUpdateRequests request);
 }

--- a/src/main/java/com/notitime/noffice/api/task/presentation/TaskApi.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/TaskApi.java
@@ -1,6 +1,7 @@
 package com.notitime.noffice.api.task.presentation;
 
 import com.notitime.noffice.api.task.presentation.dto.request.TaskModifyRequest;
+import com.notitime.noffice.api.task.presentation.dto.request.TaskStatusUpdateRequest;
 import com.notitime.noffice.api.task.presentation.dto.response.AssignedTaskResponse;
 import com.notitime.noffice.api.task.presentation.dto.response.TaskModifyResponse;
 import com.notitime.noffice.auth.AuthMember;
@@ -39,4 +40,14 @@ interface TaskApi {
 	                                                         @PageableDefault(size = 5)
 	                                                         @SortDefault(sort = "id", direction = Sort.Direction.DESC)
 	                                                         Pageable pageable);
+
+	@Operation(summary = "[인증] 사용자 투두 목록 완료 체크", description = "사용자의 조직별 투두 목록에서 완료된 투두를 체크합니다.", responses = {
+			@ApiResponse(responseCode = "204", description = "투두 상태 업데이트 성공", content = @Content),
+			@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다. 토큰을 확인해주세요.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "403", description = "요청을 수행할 수 있는 권한이 없습니다.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "404", description = "투두가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "500", description = "서버 내부 에러 발생", content = @Content(schema = @Schema(implementation = NofficeResponse.class)))
+	})
+	NofficeResponse<Void> updateTaskStatus(@Parameter(hidden = true) @AuthMember final Long memberId,
+	                                       TaskStatusUpdateRequest request);
 }

--- a/src/main/java/com/notitime/noffice/api/task/presentation/TaskController.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/TaskController.java
@@ -6,7 +6,7 @@ import static com.notitime.noffice.global.web.BusinessSuccessCode.PATCH_UPDATE_T
 
 import com.notitime.noffice.api.task.business.TaskService;
 import com.notitime.noffice.api.task.presentation.dto.request.TaskModifyRequest;
-import com.notitime.noffice.api.task.presentation.dto.request.TaskStatusUpdateRequest;
+import com.notitime.noffice.api.task.presentation.dto.request.TaskStatusUpdateRequests;
 import com.notitime.noffice.api.task.presentation.dto.response.AssignedTaskResponse;
 import com.notitime.noffice.api.task.presentation.dto.response.TaskModifyResponse;
 import com.notitime.noffice.auth.AuthMember;
@@ -47,7 +47,7 @@ public class TaskController implements TaskApi {
 
 	@PutMapping("/assigned")
 	public NofficeResponse<Void> updateTaskStatus(@AuthMember final Long memberId,
-	                                              TaskStatusUpdateRequest request) {
+	                                              TaskStatusUpdateRequests request) {
 		taskService.updateTaskStatus(memberId, request);
 		return NofficeResponse.success(PATCH_UPDATE_TASK_STATUS_SUCCESS);
 	}

--- a/src/main/java/com/notitime/noffice/api/task/presentation/TaskController.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/TaskController.java
@@ -2,9 +2,11 @@ package com.notitime.noffice.api.task.presentation;
 
 import static com.notitime.noffice.global.web.BusinessSuccessCode.GET_ASSIGNED_TASKS_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.PATCH_TASK_MODIFY_SUCCESS;
+import static com.notitime.noffice.global.web.BusinessSuccessCode.PATCH_UPDATE_TASK_STATUS_SUCCESS;
 
 import com.notitime.noffice.api.task.business.TaskService;
 import com.notitime.noffice.api.task.presentation.dto.request.TaskModifyRequest;
+import com.notitime.noffice.api.task.presentation.dto.request.TaskStatusUpdateRequest;
 import com.notitime.noffice.api.task.presentation.dto.response.AssignedTaskResponse;
 import com.notitime.noffice.api.task.presentation.dto.response.TaskModifyResponse;
 import com.notitime.noffice.auth.AuthMember;
@@ -17,6 +19,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.SortDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -40,5 +43,12 @@ public class TaskController implements TaskApi {
 	                                                                Pageable pageable) {
 		return NofficeResponse.success(GET_ASSIGNED_TASKS_SUCCESS,
 				taskService.getAssignedTasks(memberId, pageable));
+	}
+
+	@PutMapping("/assigned")
+	public NofficeResponse<Void> updateTaskStatus(@AuthMember final Long memberId,
+	                                              TaskStatusUpdateRequest request) {
+		taskService.updateTaskStatus(memberId, request);
+		return NofficeResponse.success(PATCH_UPDATE_TASK_STATUS_SUCCESS);
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/task/presentation/dto/request/TaskStatusUpdateRequest.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/dto/request/TaskStatusUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.notitime.noffice.api.task.presentation.dto.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record TaskStatusUpdateRequest(
+		@Schema(description = "투두 항목 ID 목록", example = "[1, 2, 3]", requiredMode = REQUIRED)
+		List<Long> taskIds) {
+}

--- a/src/main/java/com/notitime/noffice/api/task/presentation/dto/request/TaskStatusUpdateRequest.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/dto/request/TaskStatusUpdateRequest.java
@@ -1,11 +1,10 @@
 package com.notitime.noffice.api.task.presentation.dto.request;
 
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.List;
 
 public record TaskStatusUpdateRequest(
-		@Schema(description = "투두 항목 ID 목록", example = "[1, 2, 3]", requiredMode = REQUIRED)
-		List<Long> taskIds) {
-}
+		@Schema(description = "투두 항목 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		Long id,
+		@Schema(description = "투두 항목 상태", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+		Boolean status
+) {}

--- a/src/main/java/com/notitime/noffice/api/task/presentation/dto/request/TaskStatusUpdateRequests.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/dto/request/TaskStatusUpdateRequests.java
@@ -1,0 +1,9 @@
+package com.notitime.noffice.api.task.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record TaskStatusUpdateRequests(
+		@Schema(description = "투두 항목 상태 리스트", example = "[{\"id\": 1, \"status\": true}, {\"id\": 2, \"status\": false}, {\"id\": 3, \"status\": true}]", requiredMode = Schema.RequiredMode.REQUIRED)
+		List<TaskStatusUpdateRequest> tasks) {
+}

--- a/src/main/java/com/notitime/noffice/api/task/presentation/dto/response/TaskResponse.java
+++ b/src/main/java/com/notitime/noffice/api/task/presentation/dto/response/TaskResponse.java
@@ -3,13 +3,17 @@ package com.notitime.noffice.api.task.presentation.dto.response;
 import com.notitime.noffice.domain.task.model.Task;
 import com.notitime.noffice.domain.task.model.TaskStatus;
 
-public record TaskResponse(Long id, Long announcementId, String content) {
+public record TaskResponse(Long id, Long announcementId, String content, Boolean isMemberChecked) {
 	public static TaskResponse from(Task task) {
-		return new TaskResponse(task.getId(), task.getAnnouncement().getId(), task.getContent());
+		return new TaskResponse(task.getId(), task.getAnnouncement().getId(), task.getContent(), null);
+	}
+
+	public static TaskResponse from(Task task, Boolean isMemberChecked) {
+		return new TaskResponse(task.getId(), task.getAnnouncement().getId(), task.getContent(), isMemberChecked);
 	}
 
 	public static TaskResponse from(TaskStatus taskStatus) {
-		Task task = taskStatus.getTask();
-		return new TaskResponse(task.getId(), task.getAnnouncement().getId(), task.getContent());
+		return new TaskResponse(taskStatus.getTask().getId(), taskStatus.getTask().getAnnouncement().getId(),
+				taskStatus.getTask().getContent(), taskStatus.getIsChecked());
 	}
 }

--- a/src/main/java/com/notitime/noffice/domain/task/model/TaskStatus.java
+++ b/src/main/java/com/notitime/noffice/domain/task/model/TaskStatus.java
@@ -49,4 +49,9 @@ public class TaskStatus extends BaseTimeEntity {
 	private void setMember(Member member) {
 		this.member = member;
 	}
+
+	public void setChecked(boolean status) {
+		this.checkedAt = LocalDateTime.now();
+		this.isChecked = status;
+	}
 }

--- a/src/main/java/com/notitime/noffice/domain/task/model/TaskStatus.java
+++ b/src/main/java/com/notitime/noffice/domain/task/model/TaskStatus.java
@@ -5,6 +5,7 @@ import com.notitime.noffice.domain.member.model.Member;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -15,7 +16,7 @@ import lombok.Getter;
 @Getter
 public class TaskStatus extends BaseTimeEntity {
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	private Boolean isChecked;

--- a/src/main/java/com/notitime/noffice/domain/task/model/TaskStatus.java
+++ b/src/main/java/com/notitime/noffice/domain/task/model/TaskStatus.java
@@ -9,12 +9,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class TaskStatus extends BaseTimeEntity {
 	@Id
@@ -32,4 +29,24 @@ public class TaskStatus extends BaseTimeEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
 	private Member member;
+
+	protected TaskStatus() {
+		this.isChecked = false;
+		this.checkedAt = null;
+	}
+
+	public static TaskStatus create(Task task, Member member) {
+		TaskStatus taskStatus = new TaskStatus();
+		taskStatus.setTask(task);
+		taskStatus.setMember(member);
+		return taskStatus;
+	}
+
+	private void setTask(Task task) {
+		this.task = task;
+	}
+
+	private void setMember(Member member) {
+		this.member = member;
+	}
 }

--- a/src/main/java/com/notitime/noffice/domain/task/model/TaskStatus.java
+++ b/src/main/java/com/notitime/noffice/domain/task/model/TaskStatus.java
@@ -5,6 +5,7 @@ import com.notitime.noffice.domain.member.model.Member;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -15,7 +16,7 @@ import lombok.Getter;
 @Getter
 public class TaskStatus extends BaseTimeEntity {
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	private Boolean isChecked;
@@ -39,6 +40,7 @@ public class TaskStatus extends BaseTimeEntity {
 		TaskStatus taskStatus = new TaskStatus();
 		taskStatus.setTask(task);
 		taskStatus.setMember(member);
+		taskStatus.isChecked = false;
 		return taskStatus;
 	}
 

--- a/src/main/java/com/notitime/noffice/domain/task/persistence/TaskStatusRepository.java
+++ b/src/main/java/com/notitime/noffice/domain/task/persistence/TaskStatusRepository.java
@@ -1,7 +1,14 @@
 package com.notitime.noffice.domain.task.persistence;
 
 import com.notitime.noffice.domain.task.model.TaskStatus;
+import java.util.Collection;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TaskStatusRepository extends JpaRepository<TaskStatus, Long> {
+	@Query("SELECT ts FROM TaskStatus ts WHERE ts.task.id = :taskId AND ts.member.id = :memberId")
+	TaskStatus findByTaskIdAndMemberId(Long taskId, Long memberId);
+
+	List<TaskStatus> findByTaskIdInAndMemberIdIn(Collection<Long> taskIds, Collection<Long> memberIds);
 }

--- a/src/main/java/com/notitime/noffice/global/web/BusinessErrorCode.java
+++ b/src/main/java/com/notitime/noffice/global/web/BusinessErrorCode.java
@@ -21,7 +21,7 @@ public enum BusinessErrorCode implements ErrorCode {
 	// 401 Unauthorized
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "NOF-401", "리소스 접근 권한이 없습니다."),
 	INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "NOF-401", "유효하지 않은 액세스 토큰입니다."),
-	INVALID_ACCESS_TOKEN_VALUE(HttpStatus.UNAUTHORIZED, "NOF-401", "액세스 토큰의 값이 일치하지 않습니다."),
+	INVALID_ACCESS_TOKEN_VALUE(HttpStatus.UNAUTHORIZED, "NOF-401", "인증되지 않은 사용자입니다. 토큰을 확인해주세요."),
 	EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "NOF-401", "액세스 토큰이 만료되었습니다."),
 	INVALID_REFRESH_TOKEN_VALUE(HttpStatus.UNAUTHORIZED, "NOF-401", "리프레시 토큰의 값이 일치하지 않습니다."),
 	EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "NOF-401", "리프레시 토큰이 만료되었습니다."),

--- a/src/main/java/com/notitime/noffice/global/web/BusinessSuccessCode.java
+++ b/src/main/java/com/notitime/noffice/global/web/BusinessSuccessCode.java
@@ -53,6 +53,7 @@ public enum BusinessSuccessCode implements SuccessCode {
 	PATCH_REGISTER_MEMBER_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2081", "조직 가입 승인 성공"),
 	DELETE_PROFILE_IMAGE_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2402", "프로필 이미지 삭제 성공"),
 	PATCH_MODIFY_COVER_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2403", "공지 커버 이미지 수정 성공"),
+	PATCH_UPDATE_TASK_STATUS_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2404", "사용자 투두 리스트 업데이트 성공"),
 
 	// RESET CONTENT (2500 ~ 2599)
 	RESET_CONTENT(HttpStatus.RESET_CONTENT, "NOF-205", "리소스가 갱신되었습니다. - 205");


### PR DESCRIPTION
## 🚀 Related Issue

close: #115 

## 📌 Tasks

- [새로운 공지 추가 시 사용자 투두 목록 갱신이 이뤄지도록 추가](https://github.com/Team-Notitime/NOFFICE-SERVER/commit/c73d81b78e102a7b149794945099e9180000a90d)
- [투두 목록 조회시 사용자의 체크 여부 추가](https://github.com/Team-Notitime/NOFFICE-SERVER/commit/33d7404bdc9ea47da6926963879a8a455f5374b7)

## 📝 Details

## 📚 Remarks
- before 
```java
	private List<TaskResponse> getTop5LatestTask(Organization organization) {
		return organization.getAnnouncements().stream()
				.flatMap(announcement -> announcement.getTasks().stream()
						.sorted(Comparator.comparing(Task::getCreatedAt).reversed())
						.limit(5))
				.map(TaskResponse::from)
				.toList();
	}
```
- after 
```java
	private AssignedTaskResponse assembleUncheckedTasks(Organization organization, Long memberId) {
		List<TaskStatus> assignedTasks = taskStatusRepository.findByTaskIdInAndMemberIdIn(
						getAllTasks(organization).stream().map(Task::getId).toList(),
						List.of(memberId)
				).stream()
				.filter(ts -> !ts.getIsChecked())
				.limit(5)
				.sorted(Comparator.comparing(TaskStatus::getCreatedAt).reversed())
				.toList();
		List<TaskResponse> assembled = assignedTasks.stream()
				.map(ts -> TaskResponse.from(ts.getTask(), ts.getIsChecked()))
				.toList();
		return AssignedTaskResponse.from(organization, assembled);
	}
```