### PR TITLE
:recycle: [Refactor] S3 Bucket url VO format 재정의

### DIFF
--- a/src/main/java/com/notitime/noffice/api/image/business/ContentImageService.java
+++ b/src/main/java/com/notitime/noffice/api/image/business/ContentImageService.java
@@ -5,12 +5,13 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.notitime.noffice.api.image.business.dto.ContentImagePresignedUrlVO;
 import com.notitime.noffice.api.image.business.dto.ImagePurpose;
+import com.notitime.noffice.api.image.business.dto.PresignedUrlInfoVO;
 import com.notitime.noffice.domain.image.model.ContentImage;
 import com.notitime.noffice.domain.image.persistence.ContentImageRepository;
 import java.net.URL;
 import java.util.Date;
-import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -28,7 +29,7 @@ public class ContentImageService {
 	private final AmazonS3 s3Client;
 	private final ContentImageRepository contentImageRepository;
 
-	public Map<String, String> getPresignedUrl(String fileType, String fileName, ImagePurpose imagePurpose) {
+	public ContentImagePresignedUrlVO getPresignedUrl(String fileType, String fileName, ImagePurpose imagePurpose) {
 		if (!fileType.isEmpty()) {
 			fileName = createPath(fileType, fileName, imagePurpose);
 		}
@@ -38,8 +39,8 @@ public class ContentImageService {
 
 		ContentImage contentImage = new ContentImage(fileName, url.toString(), imagePurpose);
 		contentImageRepository.save(contentImage);
-
-		return Map.of("url", url.toString());
+		PresignedUrlInfoVO presignedUrlInfoVO = PresignedUrlInfoVO.of(url.toString());
+		return ContentImagePresignedUrlVO.of(fileName, presignedUrlInfoVO);
 	}
 
 	private GeneratePresignedUrlRequest getGeneratePresignedUrlRequest(String bucket, String fileName) {

--- a/src/main/java/com/notitime/noffice/api/image/business/dto/ContentImagePresignedUrlVO.java
+++ b/src/main/java/com/notitime/noffice/api/image/business/dto/ContentImagePresignedUrlVO.java
@@ -1,12 +1,10 @@
 package com.notitime.noffice.api.image.business.dto;
 
-import java.util.Map;
-
 public record ContentImagePresignedUrlVO(
 		String fileName,
-		Map<String, String> urls
+		PresignedUrlInfoVO urls
 ) {
-	public static ContentImagePresignedUrlVO of(String fileName, Map<String, String> urls) {
+	public static ContentImagePresignedUrlVO of(String fileName, PresignedUrlInfoVO urls) {
 		return new ContentImagePresignedUrlVO(fileName, urls);
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/image/business/dto/PresignedUrlInfoVO.java
+++ b/src/main/java/com/notitime/noffice/api/image/business/dto/PresignedUrlInfoVO.java
@@ -1,0 +1,12 @@
+package com.notitime.noffice.api.image.business.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PresignedUrlInfoVO(
+		@Schema(description = "사용자가 업로드할 파일을 저장할 URL", required = true, example = "https://example.com")
+		String url
+) {
+	public static PresignedUrlInfoVO of(String url) {
+		return new PresignedUrlInfoVO(url);
+	}
+}

--- a/src/main/java/com/notitime/noffice/api/image/presentation/ContentImageController.java
+++ b/src/main/java/com/notitime/noffice/api/image/presentation/ContentImageController.java
@@ -24,11 +24,8 @@ public class ContentImageController implements ContentImageApi {
 	@GetMapping
 	public ResponseEntity<ContentImagePresignedUrlVO> getContentImage(@RequestParam final String fileType,
 	                                                                  @RequestParam final String fileName,
-	                                                                  @RequestParam final ImagePurpose imagePurpose
-	) {
-		return ResponseEntity
-				.ok(ContentImagePresignedUrlVO.of(fileName,
-						contentImageService.getPresignedUrl(fileType, fileName, imagePurpose)));
+	                                                                  @RequestParam final ImagePurpose imagePurpose) {
+		return ResponseEntity.ok(contentImageService.getPresignedUrl(fileType, fileName, imagePurpose));
 	}
 
 	@PostMapping


### PR DESCRIPTION
## 🚀 Related Issue

close: #135

## 📌 Tasks

- [♻️ refactor: s3 image url VO 응답 타입 구체화 ](https://github.com/Team-Notitime/NOFFICE-SERVER/commit/18991f7059e3fa98e62918de0f9c2036bb9fb2f5)
## 📝 Details

- expected response type
```json
{
    "fileName": "jpeg/e9561343-1ff5-4ceb-8045-4d2b42e45ab6-cmc-logo.jpeg",
    "urls": {
        "url": "https://noffice-bucket.s3.ap-northeast-2.amazonaws.com/jpeg/e9561343-1ff5-4ceb-8045-4d2b42e45ab6-cmc-logo.jpeg?x-amz-acl=public-read&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240825T110726Z&X-Amz-SignedHeaders=host&X-Amz-Expires=239&X-Amz-Credential=AKIA5FTZCX65KMSUK7N2%2F20240825%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=8c6279e1e9bc7dad143a013ff740c0c9ac3b048cd13d691b0a7abafbf664fa52"
    }
}
```

## 📚 Remarks
<img width="750" alt="image" src="https://github.com/user-attachments/assets/fa9107fc-01e4-45f0-a737-7025b10d9125">