### PR TITLE
♻️ [Refactor] 공지 미열람자 조회 로직 개선

### DIFF
--- a/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
@@ -92,8 +92,14 @@ public class AnnouncementService {
 	}
 
 	public ReadStatusResponse getUnreadMembers(Long memberId, Long announcementId) {
-		roleVerifier.verifyJoinedMember(memberId, getOrganizationId(announcementId));
-		return ReadStatusResponse.of(announcementId, readStatusRecoder.findUnReadMembers(announcementId).stream()
+		Long organizationId = getOrganizationId(announcementId);
+		roleVerifier.verifyJoinedMember(memberId, organizationId);
+		Announcement announcement = announcementRepository.findById(announcementId)
+				.orElseThrow(() -> new NotFoundException(NOT_FOUND_ANNOUNCEMENT));
+		Organization organization = organizationRepository.findById(organizationId)
+				.orElseThrow(() -> new NotFoundException(NOT_FOUND_ORGANIZATION));
+		List<Member> unreadMembers = readStatusRecoder.findUnReadMembers(announcement, organization);
+		return ReadStatusResponse.of(announcementId, unreadMembers.stream()
 				.map(MemberInfoResponse::from)
 				.toList());
 	}

--- a/src/main/java/com/notitime/noffice/api/image/strategy/ImageRetrievalContext.java
+++ b/src/main/java/com/notitime/noffice/api/image/strategy/ImageRetrievalContext.java
@@ -3,7 +3,9 @@ package com.notitime.noffice.api.image.strategy;
 import com.notitime.noffice.api.image.presentation.dto.CommonImageResponse;
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.stereotype.Component;
 
+@Component
 public class ImageRetrievalContext {
 	private final List<ImageRetrievalStrategy<?>> strategies;
 

--- a/src/main/java/com/notitime/noffice/api/image/strategy/PromotionImageRetrievalStrategy.java
+++ b/src/main/java/com/notitime/noffice/api/image/strategy/PromotionImageRetrievalStrategy.java
@@ -4,6 +4,7 @@ import static com.notitime.noffice.api.image.business.dto.ImagePurpose.PROMOTION
 
 import com.notitime.noffice.api.image.presentation.dto.CommonImageResponse;
 import com.notitime.noffice.domain.promotion.PromotionImage;
+import com.notitime.noffice.domain.promotion.persistence.OrganizationPromotionRepository;
 import com.notitime.noffice.domain.promotion.persistence.PromotionImageRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -15,13 +16,17 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PromotionImageRetrievalStrategy implements ImageRetrievalStrategy<PromotionImage> {
 
+	private final OrganizationPromotionRepository organizationPromotionRepository;
 	private final PromotionImageRepository promotionImageRepository;
 
 	@Override
 	public List<CommonImageResponse> getSelectableImages(Long organizationId) {
-		return promotionImageRepository.findAll().stream()
-				.map(this::toResponse)
-				.toList();
+		return organizationPromotionRepository.findByOrganizationId(organizationId)
+				.filter(op -> op.getPromotion() != null)
+				.map(op -> promotionImageRepository.findAll().stream()
+						.map(this::toResponse)
+						.toList())
+				.orElseGet(List::of);
 	}
 
 	@Override

--- a/src/main/java/com/notitime/noffice/domain/announcement/model/AnnouncementReadStatus.java
+++ b/src/main/java/com/notitime/noffice/domain/announcement/model/AnnouncementReadStatus.java
@@ -9,6 +9,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -18,7 +20,8 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"member_id", "announcement_id"})})
 @Builder
 @Getter
 public class AnnouncementReadStatus extends BaseTimeEntity {

--- a/src/main/java/com/notitime/noffice/domain/organization/model/Organization.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/model/Organization.java
@@ -91,7 +91,7 @@ public class Organization extends BaseTimeEntity {
 	}
 
 	public List<Member> getMembersByStatus(JoinStatus joinStatus) {
-		return members.stream()
+		return this.members.stream()
 				.filter(organizationMember -> organizationMember.getStatus() == joinStatus)
 				.map(OrganizationMember::getMember)
 				.toList();

--- a/src/main/java/com/notitime/noffice/domain/promotion/persistence/OrganizationPromotionRepository.java
+++ b/src/main/java/com/notitime/noffice/domain/promotion/persistence/OrganizationPromotionRepository.java
@@ -5,5 +5,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrganizationPromotionRepository extends JpaRepository<OrganizationPromotion, Long> {
+	Optional<OrganizationPromotion> findByOrganizationId(Long organizationId);
+
 	Optional<OrganizationPromotion> findByOrganizationIdAndPromotionId(Long organizationId, Long promotionId);
 }


### PR DESCRIPTION
## 🚀 Related Issue

close: #139 

## 📌 Tasks

### 1. 열람/미열람자 사용자 조회 로직 개선
- 기존 로직은 `조직 내 전체 사용자 객체` 를 `열람자 사용자 객체`와의 `removeAll` 연산에서 항상 `null`을 반환함
- 두 배열 내 객체간 동등성을 검증하는 override가 가능하나, 다른 로직에서는 id 및 `organization` 내 사용자에 대한 동등성을 검토할 수 있으므로 `stream API`로 해결

### 2. 열람 기록과 조회수 간 상관관계 개선 (중복저장 변경)
- 게시글 조회 기록이 열람 시마다 기록되는 상황 (복합키 미설정에 의함)
 - 게시글 별 조회 수 등으로 풀어낼 수 있으나, 기획에서 필요하지 않은 기능임과 동시에 중복 저장된 row를 열람자 단일 기록을 위한 정보 저장소로 사용하므로, `uniqueConstraint`를 부여하여 중복 데이터 삭제 처리를 진행함

## 📝 Details
- after
```java
	public List<Member> findUnReadMembers(Announcement announcement, Organization organization) {
		Set<Long> readMemberIds = findReadMembers(announcement.getId()).stream()
				.map(Member::getId)
				.collect(Collectors.toSet());
		return organization.getMembersByStatus(JoinStatus.ACTIVE).stream()
				.filter(member -> !readMemberIds.contains(member.getId()))
				.toList();
	}
```
- before
```java
	public List<Member> findUnReadMembers(Long announcementId) {
		Organization organization = announcementRepository.findById(announcementId)
				.orElseThrow(() -> new NotFoundException(NOT_FOUND_ORGANIZATION))
				.getOrganization();
		List<Member> allMembers = organization.getMembersByStatus(JoinStatus.ACTIVE);
		List<Member> readMembers = findReadMembers(announcementId);
		allMembers.removeAll(readMembers);
		return allMembers;
	}
``` 

## 📚 Remarks

- 
- 