### PR TITLE
✨ [Feat] 소속 조직원 전체 조회 기능

### DIFF
--- a/src/main/java/com/notitime/noffice/api/image/presentation/ContentImageApi.java
+++ b/src/main/java/com/notitime/noffice/api/image/presentation/ContentImageApi.java
@@ -21,7 +21,7 @@ public interface ContentImageApi {
 	);
 
 	@Operation(summary = "컨텐츠 이미지 업로드 완료", description = "컨텐츠 이미지 업로드 완료를 노피스 서버에 알립니다.", responses = {
-			@ApiResponse(responseCode = "200", description = "별도 파일을 제외한 POST 요청을 발송해주세요.")
+			@ApiResponse(responseCode = "201", description = "별도 파일을 제외한 POST 요청을 발송해주세요.")
 	})
 	ResponseEntity<Void> notifyContentImageSaveSuccess(@RequestBody final NotifyContentImageSaveSuccessRequest request);
 }

--- a/src/main/java/com/notitime/noffice/api/organization/business/OrganizationService.java
+++ b/src/main/java/com/notitime/noffice/api/organization/business/OrganizationService.java
@@ -18,6 +18,7 @@ import com.notitime.noffice.api.organization.presentation.dto.response.Organizat
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationImageResponse;
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationInfoResponse;
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationJoinResponse;
+import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationMemberResponses;
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationResponse;
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationSignupResponse;
 import com.notitime.noffice.domain.JoinStatus;
@@ -175,5 +176,9 @@ public class OrganizationService {
 		List<Category> categories = categoryRepository.findByIdIn(request.categoryList());
 		Member leader = getMemberEntity(createMemberId);
 		return Organization.create(request.name(), request.endAt(), request.profileImage(), categories, leader);
+	}
+
+	public OrganizationMemberResponses getRegisteredMembers(Long memberId, Long organizationId) {
+		return null;
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/organization/business/OrganizationService.java
+++ b/src/main/java/com/notitime/noffice/api/organization/business/OrganizationService.java
@@ -178,7 +178,16 @@ public class OrganizationService {
 		return Organization.create(request.name(), request.endAt(), request.profileImage(), categories, leader);
 	}
 
-	public OrganizationMemberResponses getRegisteredMembers(Long memberId, Long organizationId) {
-		return null;
+	public OrganizationMemberResponses getRegisteredMembers(Long requesterMemberId, Long organizationId) {
+		roleVerifier.verifyLeader(requesterMemberId, organizationId);
+		MemberInfoResponse requester = MemberInfoResponse.from(getMemberEntity(requesterMemberId));
+		List<MemberInfoResponse> leadersWithoutRequester = organizationMemberRepository.findLeaders(organizationId)
+				.stream()
+				.filter(leader -> !leader.getId().equals(requesterMemberId))
+				.map(MemberInfoResponse::from).toList();
+		List<MemberInfoResponse> participants = organizationMemberRepository.findParticipants(organizationId)
+				.stream()
+				.map(MemberInfoResponse::from).toList();
+		return OrganizationMemberResponses.of(requester, leadersWithoutRequester, participants);
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationApi.java
+++ b/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationApi.java
@@ -10,6 +10,7 @@ import com.notitime.noffice.api.organization.presentation.dto.response.Organizat
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationImageResponse;
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationInfoResponse;
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationJoinResponse;
+import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationMemberResponses;
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationResponse;
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationSignupResponse;
 import com.notitime.noffice.auth.AuthMember;
@@ -154,4 +155,15 @@ interface OrganizationApi {
 	})
 	NofficeResponse<Void> deleteProfileImage(@Parameter(hidden = true) @AuthMember final Long memberId,
 	                                         @PathVariable Long organizationId);
+
+	@Operation(summary = "[인증] 소속 조직원 권한별 전체 조회", description = "조직 내 소속원 전체를 조회합니다. LEADER, PARTICIPANT로 구분됩니다.", responses = {
+			@ApiResponse(responseCode = "200", description = "조직 가입자 목록 조회 성공"),
+			@ApiResponse(responseCode = "400", description = "프로필 이미지 삭제 실패", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다. 토큰을 확인해주세요.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "403", description = "요청을 수행할 수 있는 권한이 없습니다.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "500", description = "서버 내부 에러 발생", content = @Content(schema = @Schema(implementation = NofficeResponse.class)))
+	})
+	NofficeResponse<OrganizationMemberResponses> getRegisteredMembers(
+			@Parameter(hidden = true) @AuthMember final Long memberId,
+			@PathVariable Long organizationId);
 }

--- a/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationController.java
+++ b/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationController.java
@@ -6,6 +6,7 @@ import static com.notitime.noffice.global.web.BusinessSuccessCode.GET_JOINED_ORG
 import static com.notitime.noffice.global.web.BusinessSuccessCode.GET_ORGANIZATION_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.GET_PENDING_MEMBERS_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.GET_PUBLISHED_ANNOUNCEMENTS_SUCCESS;
+import static com.notitime.noffice.global.web.BusinessSuccessCode.GET_REGISTERED_MEMBERS_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.GET_SELECTABLE_COVER_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.GET_SIGNUP_INFO_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.PATCH_CHANGE_ROLES_SUCCESS;
@@ -25,10 +26,12 @@ import com.notitime.noffice.api.organization.presentation.dto.response.Organizat
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationImageResponse;
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationInfoResponse;
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationJoinResponse;
+import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationMemberResponses;
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationResponse;
 import com.notitime.noffice.api.organization.presentation.dto.response.OrganizationSignupResponse;
 import com.notitime.noffice.auth.AuthMember;
 import com.notitime.noffice.global.web.NofficeResponse;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -134,5 +137,13 @@ public class OrganizationController implements OrganizationApi {
 	                                                @PathVariable Long organizationId) {
 		organizationService.deleteProfileImage(organizationId);
 		return NofficeResponse.success(DELETE_PROFILE_IMAGE_SUCCESS);
+	}
+
+	@GetMapping("/{organizationId}/members")
+	public NofficeResponse<OrganizationMemberResponses> getRegisteredMembers(
+			@Parameter(hidden = true) @AuthMember final Long memberId,
+			@PathVariable Long organizationId) {
+		return NofficeResponse.success(GET_REGISTERED_MEMBERS_SUCCESS,
+				organizationService.getRegisteredMembers(memberId, organizationId));
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/organization/presentation/dto/response/OrganizationMemberResponses.java
+++ b/src/main/java/com/notitime/noffice/api/organization/presentation/dto/response/OrganizationMemberResponses.java
@@ -1,0 +1,22 @@
+package com.notitime.noffice.api.organization.presentation.dto.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.notitime.noffice.api.member.presentation.dto.response.MemberInfoResponse;
+import com.notitime.noffice.domain.member.model.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record OrganizationMemberResponses(
+		@Schema(description = "조직의 리더 목록 (LEADER)", requiredMode = REQUIRED)
+		List<MemberInfoResponse> leaders,
+		@Schema(description = "조직의 멤버 목록 (PARTICIPANT)", requiredMode = REQUIRED)
+		List<MemberInfoResponse> participants
+) {
+	public static OrganizationMemberResponses of(List<Member> leaders, List<Member> participants) {
+		return new OrganizationMemberResponses(
+				leaders.stream().map(MemberInfoResponse::from).toList(),
+				participants.stream().map(MemberInfoResponse::from).toList()
+		);
+	}
+}

--- a/src/main/java/com/notitime/noffice/api/organization/presentation/dto/response/OrganizationMemberResponses.java
+++ b/src/main/java/com/notitime/noffice/api/organization/presentation/dto/response/OrganizationMemberResponses.java
@@ -1,22 +1,22 @@
 package com.notitime.noffice.api.organization.presentation.dto.response;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import com.notitime.noffice.api.member.presentation.dto.response.MemberInfoResponse;
-import com.notitime.noffice.domain.member.model.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 public record OrganizationMemberResponses(
+		@Schema(description = "요청자 정보 (LEADER 검증 완료)", requiredMode = REQUIRED)
+		MemberInfoResponse requester,
 		@Schema(description = "조직의 리더 목록 (LEADER)", requiredMode = REQUIRED)
 		List<MemberInfoResponse> leaders,
-		@Schema(description = "조직의 멤버 목록 (PARTICIPANT)", requiredMode = REQUIRED)
+		@Schema(description = "조직의 멤버 목록 (PARTICIPANT)", requiredMode = NOT_REQUIRED)
 		List<MemberInfoResponse> participants
 ) {
-	public static OrganizationMemberResponses of(List<Member> leaders, List<Member> participants) {
-		return new OrganizationMemberResponses(
-				leaders.stream().map(MemberInfoResponse::from).toList(),
-				participants.stream().map(MemberInfoResponse::from).toList()
-		);
+	public static OrganizationMemberResponses of(MemberInfoResponse requester, List<MemberInfoResponse> leaders,
+	                                             List<MemberInfoResponse> participants) {
+		return new OrganizationMemberResponses(requester, leaders, participants);
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/task/business/TaskStatusManager.java
+++ b/src/main/java/com/notitime/noffice/api/task/business/TaskStatusManager.java
@@ -1,5 +1,6 @@
 package com.notitime.noffice.api.task.business;
 
+import com.notitime.noffice.domain.JoinStatus;
 import com.notitime.noffice.domain.announcement.model.Announcement;
 import com.notitime.noffice.domain.member.model.Member;
 import com.notitime.noffice.domain.organization.model.Organization;
@@ -23,22 +24,14 @@ public class TaskStatusManager {
 	private final OrganizationMemberRepository organizationMemberRepository;
 
 	public void assignTasks(Organization organization, Announcement announcement) {
-		List<Member> members = getParticipants(organization.getId());
-		List<Member> leaders = getLeaders(organization.getId());
-		members.addAll(leaders);
-		List<TaskStatus> taskStatuses = members.stream()
+		List<Member> activeMembers = organizationMemberRepository.findMembersByOrganizationIdAndStatus(
+				organization.getId(),
+				JoinStatus.ACTIVE);
+		List<TaskStatus> taskStatuses = activeMembers.stream()
 				.flatMap(member -> announcement.getTasks().stream()
 						.map(task -> TaskStatus.create(task, member)))
 				.toList();
 		taskStatusRepository.saveAll(taskStatuses);
-	}
-
-	private List<Member> getLeaders(Long organizationId) {
-		return organizationMemberRepository.findLeadersByOrganizationId(organizationId);
-	}
-
-	private List<Member> getParticipants(Long organizationId) {
-		return organizationMemberRepository.findParticipantsByOrganizationId(organizationId);
 	}
 
 //	public void recordTaskStatus(Long memberId, Long taskId) {

--- a/src/main/java/com/notitime/noffice/domain/organization/persistence/OrganizationMemberRepository.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/persistence/OrganizationMemberRepository.java
@@ -26,6 +26,9 @@ public interface OrganizationMemberRepository extends JpaRepository<Organization
 	@Query("SELECT om.member FROM OrganizationMember om WHERE om.organization.id = :organizationId")
 	Slice<Member> findMembersByOrganizationId(@Param("organizationId") Long organizationId, Pageable pageable);
 
+	@Query("SELECT om.member FROM OrganizationMember om WHERE om.organization.id = :organizationId AND om.status = :status")
+	List<Member> findMembersByOrganizationIdAndStatus(Long organizationId, JoinStatus status);
+
 	@Query("SELECT om.member FROM OrganizationMember om WHERE om.organization.id = :organizationId AND om.role = :role")
 	List<Member> findMembersByOrganizationIdAndRole(@Param("organizationId") Long organizationId,
 	                                                @Param("role") OrganizationRole role);
@@ -40,11 +43,11 @@ public interface OrganizationMemberRepository extends JpaRepository<Organization
 	int bulkUpdateStatus(@Param("organizationId") Long organizationId, @Param("memberIds") List<Long> memberIds,
 	                     @Param("status") JoinStatus status);
 
-	default List<Member> findLeadersByOrganizationId(Long organizationId) {
+	default List<Member> findLeaders(Long organizationId) {
 		return findMembersByOrganizationIdAndRole(organizationId, LEADER);
 	}
 
-	default List<Member> findParticipantsByOrganizationId(Long organizationId) {
+	default List<Member> findParticipants(Long organizationId) {
 		return findMembersByOrganizationIdAndRole(organizationId, PARTICIPANT);
 	}
 

--- a/src/main/java/com/notitime/noffice/global/web/BusinessSuccessCode.java
+++ b/src/main/java/com/notitime/noffice/global/web/BusinessSuccessCode.java
@@ -33,6 +33,7 @@ public enum BusinessSuccessCode implements SuccessCode {
 	GET_UNREAD_MEMBERS_SUCCESS(HttpStatus.OK, "NOF-2085", "공지 미열람 사용자 목록 조회 성공"),
 	GET_PENDING_MEMBERS_SUCCESS(HttpStatus.OK, "NOF-2086", "조직 가입 대기자 목록 조회 성공"),
 	GET_SELECTABLE_COVER_SUCCESS(HttpStatus.OK, "NOF-2087", "선택 가능한 공지 커버 이미지 목록 조회 성공"),
+	GET_REGISTERED_MEMBERS_SUCCESS(HttpStatus.OK, "NOF-2088", "조직 가입자 목록 조회 성공"),
 
 	// CREATED (2100 ~ 2199)
 	CREATED(HttpStatus.CREATED, "NOF-210", "리소스가 생성되었습니다. - 201"),


### PR DESCRIPTION
## 🚀 Related Issue

close: #141 

## 📌 Tasks

- [Feat] 소속 조직원 전체 조회 기능
- `GET` | `/api/v1/organizations/{organizationId}/members`

## 📝 Details

- [✨ feat: 소속 조직원 권한별 전체 조회 기능 Business ](https://github.com/Team-Notitime/NOFFICE-SERVER/commit/670a088e97255445aee01fd047ee60133da57eb6)

## 📚 Remarks

- [📝 docs: S3 이미지 업로드 완료 요청 httpstatuscode 매핑 수정](https://github.com/Team-Notitime/NOFFICE-SERVER/commit/d0eac7770bd436632e2015f0d2debf27a2e6361b)
- _200_ -> _201_ ( in `POST` | `/api/v1/image`)