### PR TITLE
:bug: [Fix] 노티 조회 시 열람 기록 중복 INSERT 발생 오류

### DIFF
--- a/src/main/java/com/notitime/noffice/api/announcement/business/ReadStatusRecoder.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/business/ReadStatusRecoder.java
@@ -24,12 +24,16 @@ public class ReadStatusRecoder {
 	private final AnnouncementRepository announcementRepository;
 
 	public void record(Member member, Announcement announcement) {
-		announcementReadStatusRepository.save(AnnouncementReadStatus.builder()
-				.readAt(LocalDateTime.now())
-				.isRead(true)
-				.member(member)
-				.announcement(announcement)
-				.build());
+		boolean isAlreadyRead = announcementReadStatusRepository.existsByMemberIdAndAnnouncementId(member.getId(),
+				announcement.getId());
+		if (!isAlreadyRead) {
+			announcementReadStatusRepository.save(AnnouncementReadStatus.builder()
+					.readAt(LocalDateTime.now())
+					.isRead(true)
+					.member(member)
+					.announcement(announcement)
+					.build());
+		}
 	}
 
 	public List<Member> findReadMembers(Long announcementId) {


### PR DESCRIPTION
## 🚀 Related Issue

close: #143

## 📌 Tasks

- 노티 조회 시 열람 기록 중복 INSERT 발생 오류

## 📝 Details
- validate with exist query
```java
	public void record(Member member, Announcement announcement) {
		boolean isAlreadyRead = announcementReadStatusRepository.existsByMemberIdAndAnnouncementId(member.getId(),
				announcement.getId());
		if (!isAlreadyRead) {
			announcementReadStatusRepository.save(AnnouncementReadStatus.builder()
					.readAt(LocalDateTime.now())
					.isRead(true)
					.member(member)
					.announcement(announcement)
					.build());
		}
	}
```

## 📚 Remarks

- 