### PR TITLE
🐛 [Fix] 조직 내 사용자 권한 변경 오류

### DIFF
--- a/src/main/java/com/notitime/noffice/api/organization/business/OrganizationService.java
+++ b/src/main/java/com/notitime/noffice/api/organization/business/OrganizationService.java
@@ -110,8 +110,12 @@ public class OrganizationService {
 
 	public void changeRoles(Long memberId, Long organizationId, ChangeRoleRequest request) {
 		roleVerifier.verifyLeader(memberId, organizationId);
-		roleVerifier.verifyMultipleMembers(organizationId, request.memberIds());
-		organizationMemberRepository.bulkUpdateRole(organizationId, request.memberIds(), request.role());
+		List<Long> activeMemberIds = organizationMemberRepository.findMembersByStatus(organizationId,
+				request.memberIds(), ACTIVE);
+		if (activeMemberIds.size() != request.memberIds().size()) {
+			throw new ForbiddenException(FORBIDDEN_CHANGE_ROLE_ACCESS);
+		}
+		organizationMemberRepository.bulkUpdateRole(organizationId, activeMemberIds, request.role());
 	}
 
 	public List<MemberInfoResponse> getPendingMembers(Long memberId, Long organizationId) {

--- a/src/main/java/com/notitime/noffice/api/organization/business/OrganizationService.java
+++ b/src/main/java/com/notitime/noffice/api/organization/business/OrganizationService.java
@@ -71,7 +71,7 @@ public class OrganizationService {
 	}
 
 	public OrganizationSignupResponse getSignUpInfo(Long memberId, Long organizationId) {
-		if (roleVerifier.isMemberInOrganization(memberId, organizationId)) {
+		if (organizationMemberRepository.existsByMemberIdAndOrganizationId(memberId, organizationId)) {
 			throw new ForbiddenException(ALREADY_JOINED_ORGANIZATION);
 		}
 		return OrganizationSignupResponse.of(getOrganizationEntity(organizationId));

--- a/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationApi.java
+++ b/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationApi.java
@@ -102,10 +102,8 @@ interface OrganizationApi {
 
 	@Operation(summary = "[인증] 조직원 권한 변경", description = "타겟에 해당하는 멤버의 조직 내 권한을 입력한 권한대로 변경합니다.", responses = {
 			@ApiResponse(responseCode = "204", description = "권한 변경에 성공하였습니다."),
-			@ApiResponse(responseCode = "400", description = "권한 변경에 실패하였습니다.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
 			@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다. 토큰을 확인해주세요.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
-			@ApiResponse(responseCode = "403", description = "요청을 수행할 수 있는 권한이 없습니다.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
-			@ApiResponse(responseCode = "404", description = "조직원이 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "403", description = "[권한 오류]: 변경할 수 없는 멤버가 포함되어 있습니다.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
 			@ApiResponse(responseCode = "500", description = "서버 내부 에러 발생", content = @Content(schema = @Schema(implementation = NofficeResponse.class)))
 	})
 	NofficeResponse<Void> changeRoles(@Parameter(hidden = true) @AuthMember Long memberId,

--- a/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationApi.java
+++ b/src/main/java/com/notitime/noffice/api/organization/presentation/OrganizationApi.java
@@ -104,7 +104,7 @@ interface OrganizationApi {
 			@ApiResponse(responseCode = "204", description = "권한 변경에 성공하였습니다."),
 			@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다. 토큰을 확인해주세요.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
 			@ApiResponse(responseCode = "403", description = "[권한 오류]: 변경할 수 없는 멤버가 포함되어 있습니다.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
-			@ApiResponse(responseCode = "500", description = "서버 내부 에러 발생", content = @Content(schema = @Schema(implementation = NofficeResponse.class)))
+			@ApiResponse(responseCode = "500", description = "[서버 내부 에러 발생]: 변경 역할 명 입력 오류", content = @Content(schema = @Schema(implementation = NofficeResponse.class)))
 	})
 	NofficeResponse<Void> changeRoles(@Parameter(hidden = true) @AuthMember Long memberId,
 	                                  @PathVariable Long organizationId,

--- a/src/main/java/com/notitime/noffice/domain/organization/persistence/OrganizationMemberRepository.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/persistence/OrganizationMemberRepository.java
@@ -54,17 +54,16 @@ public interface OrganizationMemberRepository extends JpaRepository<Organization
 	boolean existsByMemberIdAndOrganizationId(Long memberId, Long organizationId);
 
 	boolean existsByMemberIdAndOrganizationIdAndStatus(Long memberId, Long organizationId, JoinStatus status);
-
-	boolean existsByMemberIdAndOrganizationIdAndRoleAndStatus(Long memberId, Long organizationId, OrganizationRole role,
-	                                                          JoinStatus status);
+	
+	boolean existsByMemberIdAndOrganizationIdAndRole(Long memberId, Long organizationId, OrganizationRole role);
 
 	Long countByOrganizationIdAndRole(Long organizationId, OrganizationRole role);
 
 	boolean existsByOrganizationIdAndStatus(Long organizationId, JoinStatus status);
 
-	@Query("SELECT om.member.id FROM OrganizationMember om WHERE om.organization.id = :organizationId AND om.member.id IN :memberIds AND om.status = 'PENDING'")
-	List<Long> findPendingMemberIds(@Param("organizationId") Long organizationId,
-	                                @Param("memberIds") List<Long> memberIds);
+	@Query("SELECT om.member.id FROM OrganizationMember om WHERE om.organization.id = :organizationId AND om.member.id IN :memberIds AND om.status = :status")
+	List<Long> findMembersByStatus(@Param("organizationId") Long organizationId,
+	                               @Param("memberIds") List<Long> memberIds, JoinStatus status);
 
 	@Query("SELECT om.member FROM OrganizationMember om WHERE om.organization.id = :organizationId AND om.status = 'PENDING'")
 	List<Member> findPendingMembers(Long organizationId);

--- a/src/main/java/com/notitime/noffice/global/web/BusinessErrorCode.java
+++ b/src/main/java/com/notitime/noffice/global/web/BusinessErrorCode.java
@@ -31,10 +31,12 @@ public enum BusinessErrorCode implements ErrorCode {
 	MISSING_BEARER_PREFIX(HttpStatus.UNAUTHORIZED, "NOF-401", "Bearer가 누락되었습니다."),
 
 	// 403 Forbidden
-	FORBIDDEN(HttpStatus.FORBIDDEN, "NOF-403", "리소스에 대한 접근 권한이 없습니다."),
-	FORBIDDEN_ORGANIZATION_ACCESS(HttpStatus.FORBIDDEN, "NOF-403", "조직에 대한 접근 권한이 없습니다."),
-	FORBIDDEN_ROLE_ACCESS(HttpStatus.FORBIDDEN, "NOF-403", "해당 조직의 권한이 올바르지 않습니다."),
-	ALREADY_JOINED_ORGANIZATION(HttpStatus.FORBIDDEN, "NOF-4034", "이미 가입 신청 이력이 존재합니다."),
+	FORBIDDEN(HttpStatus.FORBIDDEN, "NOF-430", "리소스에 대한 접근 권한이 없습니다."),
+	FORBIDDEN_ORGANIZATION_ACCESS(HttpStatus.FORBIDDEN, "NOF-4301", "조직에 대한 접근 권한이 없습니다."),
+	FORBIDDEN_CHANGE_ROLE_ACCESS(HttpStatus.FORBIDDEN, "NOF-4302", "[권한 오류]: 변경할 수 없는 멤버가 포함되어 있습니다."),
+	FORBIDDEN_ROLE_ACCESS(HttpStatus.FORBIDDEN, "NOF-4303", "해당 조직의 권한이 올바르지 않습니다."),
+	ALREADY_JOINED_ORGANIZATION(HttpStatus.FORBIDDEN, "NOF-4304", "이미 가입 신청 이력이 존재합니다."),
+	FORBIDDEN_REGISTER_MEMBER_ACCESS(HttpStatus.FORBIDDEN, "NOF-4305", "멤버 등록 권한이 없습니다."),
 
 	// 404 Not Found
 	NOT_FOUND(HttpStatus.NOT_FOUND, "NOF-404", "리소스를 찾을 수 없습니다."),


### PR DESCRIPTION
## 🚀 Related Issue

close: #145 

## 📌 Tasks

- 역할 변경을 요청한 사용자 식별자를 `ACTIVE` 멤버에서 찾지 않고, `PENDING`에서 찾아 항상 예외를 반환하는 문제

## 📝 Details

- 가입 기록에 따른 역할 조회의 책임만을 갖는 `RoleVerifier`는 가입 기록 조회의 책임을 가지지 않음
- `RoleVerifier`의 조회 로직을 `OrganizationService`로 위임
```java
public void changeRoles(Long memberId, Long organizationId, ChangeRoleRequest request) {
	roleVerifier.verifyLeader(memberId, organizationId);
	List<Long> activeMemberIds = getActiveMemberIds(organizationId, request.memberIds());
	if (!areAllMembersActive(request.memberIds(), activeMemberIds)) {
		throw new ForbiddenException(FORBIDDEN_CHANGE_ROLE_ACCESS);
	}
	updateRoles(organizationId, activeMemberIds, request.role());
}
```

## 📚 Remarks

- 조직 내 사용자 권한 변경 오류
```json
{
  "timestamp": "2024-08-27T00:10:43.346310365",
  "httpStatus": 404,
  "code": "NOF-4470",
  "message": "멤버를 찾을 수 없습니다."
}
```