### PR TITLE
:sparkles: [Feat] 조직 내 멤버 Soft delete 추가

### DIFF
--- a/src/main/java/com/notitime/noffice/api/member/business/MemberService.java
+++ b/src/main/java/com/notitime/noffice/api/member/business/MemberService.java
@@ -19,29 +19,34 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 
 	public MemberResponse getMember(Long memberId) {
-		return MemberResponse.of(getMemberEntity(memberId));
-	}
-
-	private Member getMemberEntity(Long memberId) {
-		return memberRepository.findById(memberId)
-				.orElseThrow(() -> new NotFoundException(BusinessErrorCode.NOT_FOUND_MEMBER));
+		return MemberResponse.of(findById(memberId));
 	}
 
 	public void deleteProfileImage(Long memberId) {
-		Member member = getMemberEntity(memberId);
+		Member member = findById(memberId);
 		member.deleteProfileImage();
 		memberRepository.save(member);
 	}
 
 	public void updateAlias(Long memberId, MemberAliasUpdateRequest request) {
-		Member member = getMemberEntity(memberId);
+		Member member = findById(memberId);
 		member.updateAlias(request.alias());
 		memberRepository.save(member);
 	}
 
 	public void updateProfileImage(Long memberId, MemberProfileUpdateRequest request) {
-		Member member = getMemberEntity(memberId);
+		Member member = findById(memberId);
 		member.updateProfileImage(request.imageUrl());
 		memberRepository.save(member);
+	}
+
+	public void deleteById(Long memberId) {
+		Member member = findById(memberId);
+		memberRepository.delete(member);
+	}
+
+	private Member findById(Long memberId) {
+		return memberRepository.findById(memberId)
+				.orElseThrow(() -> new NotFoundException(BusinessErrorCode.NOT_FOUND_MEMBER));
 	}
 }

--- a/src/main/java/com/notitime/noffice/domain/member/model/Member.java
+++ b/src/main/java/com/notitime/noffice/domain/member/model/Member.java
@@ -59,7 +59,7 @@ public class Member extends BaseTimeEntity {
 	@ColumnDefault("null")
 	private LocalDateTime deletedAt;
 
-	@OneToMany(mappedBy = "member")
+	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
 	private final List<OrganizationMember> organizations = new ArrayList<>();
 
 	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/notitime/noffice/domain/member/model/Member.java
+++ b/src/main/java/com/notitime/noffice/domain/member/model/Member.java
@@ -6,6 +6,7 @@ import com.notitime.noffice.domain.JoinStatus;
 import com.notitime.noffice.domain.SocialAuthProvider;
 import com.notitime.noffice.domain.organization.model.Organization;
 import com.notitime.noffice.domain.organization.model.OrganizationMember;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -14,6 +15,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -21,12 +23,17 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE member SET deleted_at = NOW() WHERE id = ?")
 public class Member extends BaseTimeEntity {
 
 	@Id
@@ -49,10 +56,13 @@ public class Member extends BaseTimeEntity {
 	@Enumerated(EnumType.STRING)
 	private SocialAuthProvider socialAuthProvider;
 
+	@ColumnDefault("null")
+	private LocalDateTime deletedAt;
+
 	@OneToMany(mappedBy = "member")
 	private final List<OrganizationMember> organizations = new ArrayList<>();
 
-	@OneToMany(mappedBy = "member")
+	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
 	private final List<FcmToken> fcmTokens = new ArrayList<>();
 
 	public static Member createAuthorizedMember(


### PR DESCRIPTION
## 🚀 Related Issue

close: #22 

## 📌 Tasks

- [✨ feat: 회원 엔티티 soft delete 삭제 방식으로 변경 ](https://github.com/Team-Notitime/NOFFICE-SERVER/commit/655ffe6023435a43a2efd2f8cdf4d3420197a99f)

## 📝 Details

- 별도 쿼리 작성 대신 delete 요청 시 명시된 쿼리가 발생하도록 작성
```java
@Entity
@SQLRestriction("deleted_at IS NULL")
@SQLDelete(sql = "UPDATE member SET deleted_at = NOW() WHERE id = ?")
public class Member extends BaseTimeEntity
//...
```

## 📚 Remarks

- 
- 