### PR TITLE
✨ [Feat] 회원 탈퇴 및 로그아웃, JWT 재발급 로직 개선

### DIFF
--- a/src/main/java/com/notitime/noffice/api/auth/business/AuthService.java
+++ b/src/main/java/com/notitime/noffice/api/auth/business/AuthService.java
@@ -39,6 +39,12 @@ public class AuthService {
 		return TokenResponse.toResponse(jwtTokenProvider.issueTokens(memberId));
 	}
 
+	public void logout(final String refreshToken) {
+		String parsedRefreshToken = refreshToken.substring("Bearer ".length());
+		jwtValidator.validateRefreshToken(parsedRefreshToken);
+		refreshTokenRepository.deleteByRefreshToken(parsedRefreshToken);
+	}
+
 	public Long getAuthorizedMemberId(String parsedRefreshToken) {
 		jwtValidator.validateRefreshToken(parsedRefreshToken);
 		RefreshToken storedRefreshToken = refreshTokenRepository.findByRefreshToken(parsedRefreshToken)

--- a/src/main/java/com/notitime/noffice/api/auth/business/AuthService.java
+++ b/src/main/java/com/notitime/noffice/api/auth/business/AuthService.java
@@ -44,8 +44,7 @@ public class AuthService {
 		return TokenResponse.toResponse(response);
 	}
 
-	public void logout(Long memberId, final String refreshToken) {
-		jwtValidator.validateRefreshToken(refreshToken);
+	public void logout(Long memberId) {
 		refreshTokenRepository.deleteByMemberId(memberId);
 	}
 

--- a/src/main/java/com/notitime/noffice/api/auth/business/AuthService.java
+++ b/src/main/java/com/notitime/noffice/api/auth/business/AuthService.java
@@ -43,21 +43,14 @@ public class AuthService {
 		return TokenResponse.toResponse(jwtTokenProvider.issueTokens(memberId));
 	}
 
-	public void logout(final String refreshToken) {
-		String parsedRefreshToken = refreshToken.substring("Bearer ".length());
-		jwtValidator.validateRefreshToken(parsedRefreshToken);
-		refreshTokenRepository.deleteByRefreshToken(parsedRefreshToken);
-	}
-
-	public Long getAuthorizedMemberId(String parsedRefreshToken) {
-		jwtValidator.validateRefreshToken(parsedRefreshToken);
-		RefreshToken storedRefreshToken = refreshTokenRepository.findByRefreshToken(parsedRefreshToken)
-				.orElseThrow(() -> new BadRequestException(INVALID_REFRESH_TOKEN_VALUE));
-		return storedRefreshToken.getMember().getId();
+	public void logout(Long memberId, final String refreshToken) {
+		jwtValidator.validateRefreshToken(refreshToken);
+		refreshTokenRepository.deleteByMemberId(memberId);
 	}
 
 	public void withdrawal(Long memberId) {
-		memberRepository.deleteById(memberId);
 		fcmTokenRepository.deleteByMemberId(memberId);
+		refreshTokenRepository.deleteByMemberId(memberId);
+		memberRepository.deleteById(memberId);
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/auth/business/strategy/AppleAuthStrategy.java
+++ b/src/main/java/com/notitime/noffice/api/auth/business/strategy/AppleAuthStrategy.java
@@ -1,6 +1,11 @@
 package com.notitime.noffice.api.auth.business.strategy;
 
+import com.notitime.noffice.api.auth.presentation.dto.request.SocialAuthRequest;
+import com.notitime.noffice.api.auth.presentation.dto.response.SocialAuthResponse;
+import com.notitime.noffice.api.auth.presentation.dto.response.TokenResponse;
 import com.notitime.noffice.auth.jwt.JwtProvider;
+import com.notitime.noffice.domain.RefreshToken;
+import com.notitime.noffice.domain.RefreshTokenRepository;
 import com.notitime.noffice.domain.SocialAuthProvider;
 import com.notitime.noffice.domain.member.model.Member;
 import com.notitime.noffice.domain.member.persistence.MemberRepository;
@@ -10,9 +15,6 @@ import com.notitime.noffice.external.openfeign.apple.AppleOAuthProvider;
 import com.notitime.noffice.external.openfeign.apple.ApplePublicKeyGenerator;
 import com.notitime.noffice.external.openfeign.apple.dto.ApplePublicKeys;
 import com.notitime.noffice.external.openfeign.dto.AuthorizedMemberInfo;
-import com.notitime.noffice.api.auth.presentation.dto.request.SocialAuthRequest;
-import com.notitime.noffice.api.auth.presentation.dto.response.SocialAuthResponse;
-import com.notitime.noffice.api.auth.presentation.dto.response.TokenResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -28,6 +30,7 @@ public class AppleAuthStrategy implements SocialAuthStrategy {
 	private final AppleIdentityTokenParser appleIdentityTokenParser;
 	private final ApplePublicKeyGenerator applePublicKeyGenerator;
 	private final MemberRepository memberRepository;
+	private final RefreshTokenRepository refreshTokenRepository;
 
 	@Value("${oauth.apple.client-id}")
 	private String clientId;
@@ -57,6 +60,7 @@ public class AppleAuthStrategy implements SocialAuthStrategy {
 						"https://www.apple.com/ac/structured-data/images/knowledge_graph_logo.png?202106171739"));
 		memberRepository.save(member);
 		TokenResponse tokenResponse = TokenResponse.toResponse(jwtProvider.issueTokens(member.getId()));
+		refreshTokenRepository.save(RefreshToken.of(member, tokenResponse.refreshToken()));
 		return SocialAuthResponse.of(member.getId(), member.getName(), request.provider(), tokenResponse);
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/auth/business/strategy/GoogleAuthStrategy.java
+++ b/src/main/java/com/notitime/noffice/api/auth/business/strategy/GoogleAuthStrategy.java
@@ -4,6 +4,8 @@ import com.notitime.noffice.api.auth.presentation.dto.request.SocialAuthRequest;
 import com.notitime.noffice.api.auth.presentation.dto.response.SocialAuthResponse;
 import com.notitime.noffice.api.auth.presentation.dto.response.TokenResponse;
 import com.notitime.noffice.auth.jwt.JwtProvider;
+import com.notitime.noffice.domain.RefreshToken;
+import com.notitime.noffice.domain.RefreshTokenRepository;
 import com.notitime.noffice.domain.SocialAuthProvider;
 import com.notitime.noffice.domain.member.model.Member;
 import com.notitime.noffice.domain.member.persistence.MemberRepository;
@@ -21,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class GoogleAuthStrategy implements SocialAuthStrategy {
 
+	private final RefreshTokenRepository refreshTokenRepository;
 	@Value("${oauth.google.client-id}")
 	private String googleClientId;
 	@Value("${oauth.google.client-secret}")
@@ -61,6 +64,7 @@ public class GoogleAuthStrategy implements SocialAuthStrategy {
 						memberResponse.picture()));
 		memberRepository.save(member);
 		TokenResponse tokenResponse = TokenResponse.toResponse(jwtProvider.issueTokens(member.getId()));
+		refreshTokenRepository.save(RefreshToken.of(member, tokenResponse.refreshToken()));
 		return SocialAuthResponse.of(member.getId(), member.getName(), request.provider(), tokenResponse);
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/member/presentation/MemberApi.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/MemberApi.java
@@ -38,8 +38,14 @@ interface MemberApi {
 			@ApiResponse(responseCode = "500", description = "서버 내부 에러 발생", content = @Content(schema = @Schema(implementation = NofficeResponse.class)))
 	})
 	NofficeResponse<Void> logout(@Parameter(hidden = true) @AuthMember final Long memberId,
-	                             @RequestHeader("refresh-token") final String refreshToken,
 	                             @RequestHeader("notification-token") final String notificationToken);
+
+	@Operation(summary = "[인증] 회원 탈퇴", description = "회원의 계정을 탈퇴합니다. 탈퇴 시 회원의 모든 정보가 삭제됩니다.", responses = {
+			@ApiResponse(responseCode = "204", description = "회원 탈퇴에 성공하였습니다."),
+			@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다. 토큰을 확인해주세요.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "500", description = "서버 내부 에러 발생", content = @Content(schema = @Schema(implementation = NofficeResponse.class)))
+	})
+	NofficeResponse<Void> withdrawal(@Parameter(hidden = true) @AuthMember final Long memberId);
 
 	@Operation(summary = "[인증] 단일 회원 정보 조회", description = "회원의 정보를 조회합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "회원 정보 조회에 성공하였습니다."),

--- a/src/main/java/com/notitime/noffice/api/member/presentation/MemberApi.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/MemberApi.java
@@ -32,6 +32,15 @@ interface MemberApi {
 	})
 	NofficeResponse<TokenResponse> reissue(@RequestHeader("Authorization") final String refreshToken);
 
+	@Operation(summary = "[인증] 회원 로그아웃", description = "회원의 계정에 저장된 Fcm 토큰을 모두 삭제합니다. 신규 로그인 시 토큰을 재요청해야합니다.", responses = {
+			@ApiResponse(responseCode = "204", description = "로그아웃에 성공하였습니다."),
+			@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다. 토큰을 확인해주세요.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "500", description = "서버 내부 에러 발생", content = @Content(schema = @Schema(implementation = NofficeResponse.class)))
+	})
+	NofficeResponse<Void> logout(@Parameter(hidden = true) @AuthMember final Long memberId,
+	                             @RequestHeader("refresh-token") final String refreshToken,
+	                             @RequestHeader("notification-token") final String notificationToken);
+
 	@Operation(summary = "[인증] 단일 회원 정보 조회", description = "회원의 정보를 조회합니다.", responses = {
 			@ApiResponse(responseCode = "200", description = "회원 정보 조회에 성공하였습니다."),
 			@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다. 토큰을 확인해주세요.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
@@ -65,5 +74,4 @@ interface MemberApi {
 	})
 	NofficeResponse<Void> updateMemberProfile(@Parameter(hidden = true) @AuthMember final Long memberId,
 	                                          @RequestBody final MemberProfileUpdateRequest request);
-
 }

--- a/src/main/java/com/notitime/noffice/api/member/presentation/MemberController.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/MemberController.java
@@ -53,8 +53,8 @@ public class MemberController implements MemberApi {
 	public NofficeResponse<Void> logout(@AuthMember final Long memberId,
 	                                    @RequestHeader("refresh-token") final String refreshToken,
 	                                    @RequestHeader("notification-token") final String notificationToken) {
+		authService.logout(memberId, refreshToken);
 		notificationService.deleteFcmToken(memberId, notificationToken);
-		authService.logout(refreshToken);
 		return NofficeResponse.success(POST_LOGOUT_SUCCESS);
 	}
 

--- a/src/main/java/com/notitime/noffice/api/member/presentation/MemberController.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/MemberController.java
@@ -7,6 +7,7 @@ import static com.notitime.noffice.global.web.BusinessSuccessCode.PATCH_UPDATE_P
 import static com.notitime.noffice.global.web.BusinessSuccessCode.POST_LOGIN_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.POST_LOGOUT_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.POST_REISSUE_SUCCESS;
+import static com.notitime.noffice.global.web.BusinessSuccessCode.POST_WITHDRAWAL_SUCCESS;
 
 import com.notitime.noffice.api.auth.business.AuthService;
 import com.notitime.noffice.api.auth.presentation.dto.request.SocialAuthRequest;
@@ -55,6 +56,12 @@ public class MemberController implements MemberApi {
 		notificationService.deleteFcmToken(memberId, notificationToken);
 		authService.logout(refreshToken);
 		return NofficeResponse.success(POST_LOGOUT_SUCCESS);
+	}
+
+	@DeleteMapping("/withdrawal")
+	public NofficeResponse<Void> withdrawal(@AuthMember final Long memberId) {
+		authService.withdrawal(memberId);
+		return NofficeResponse.success(POST_WITHDRAWAL_SUCCESS);
 	}
 
 	@GetMapping

--- a/src/main/java/com/notitime/noffice/api/member/presentation/MemberController.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/MemberController.java
@@ -51,9 +51,8 @@ public class MemberController implements MemberApi {
 
 	@PostMapping("/logout")
 	public NofficeResponse<Void> logout(@AuthMember final Long memberId,
-	                                    @RequestHeader("refresh-token") final String refreshToken,
 	                                    @RequestHeader("notification-token") final String notificationToken) {
-		authService.logout(memberId, refreshToken);
+		authService.logout(memberId);
 		notificationService.deleteFcmToken(memberId, notificationToken);
 		return NofficeResponse.success(POST_LOGOUT_SUCCESS);
 	}

--- a/src/main/java/com/notitime/noffice/api/member/presentation/MemberController.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/MemberController.java
@@ -5,6 +5,7 @@ import static com.notitime.noffice.global.web.BusinessSuccessCode.GET_MEMBER_SUC
 import static com.notitime.noffice.global.web.BusinessSuccessCode.PATCH_UPDATE_ALIAS_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.PATCH_UPDATE_PROFILE_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.POST_LOGIN_SUCCESS;
+import static com.notitime.noffice.global.web.BusinessSuccessCode.POST_LOGOUT_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.POST_REISSUE_SUCCESS;
 
 import com.notitime.noffice.api.auth.business.AuthService;
@@ -15,6 +16,7 @@ import com.notitime.noffice.api.member.business.MemberService;
 import com.notitime.noffice.api.member.presentation.dto.request.MemberAliasUpdateRequest;
 import com.notitime.noffice.api.member.presentation.dto.request.MemberProfileUpdateRequest;
 import com.notitime.noffice.api.member.presentation.dto.response.MemberResponse;
+import com.notitime.noffice.api.notification.business.NotificationService;
 import com.notitime.noffice.auth.AuthMember;
 import com.notitime.noffice.global.web.NofficeResponse;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +36,7 @@ public class MemberController implements MemberApi {
 
 	private final AuthService authService;
 	private final MemberService memberService;
+	private final NotificationService notificationService;
 
 	@PostMapping("/login")
 	public NofficeResponse<SocialAuthResponse> login(@RequestBody final SocialAuthRequest socialLoginRequest) {
@@ -43,6 +46,15 @@ public class MemberController implements MemberApi {
 	@PostMapping("/reissue")
 	public NofficeResponse<TokenResponse> reissue(@RequestHeader("Authorization") final String refreshToken) {
 		return NofficeResponse.success(POST_REISSUE_SUCCESS, authService.reissue(refreshToken));
+	}
+
+	@PostMapping("/logout")
+	public NofficeResponse<Void> logout(@AuthMember final Long memberId,
+	                                    @RequestHeader("refresh-token") final String refreshToken,
+	                                    @RequestHeader("notification-token") final String notificationToken) {
+		notificationService.deleteFcmToken(memberId, notificationToken);
+		authService.logout(refreshToken);
+		return NofficeResponse.success(POST_LOGOUT_SUCCESS);
 	}
 
 	@GetMapping

--- a/src/main/java/com/notitime/noffice/api/notification/business/NotificationService.java
+++ b/src/main/java/com/notitime/noffice/api/notification/business/NotificationService.java
@@ -1,6 +1,5 @@
 package com.notitime.noffice.api.notification.business;
 
-import static com.notitime.noffice.global.web.BusinessErrorCode.NOT_FOUND_FCM_TOKEN;
 import static com.notitime.noffice.global.web.BusinessErrorCode.NOT_FOUND_MEMBER;
 
 import com.notitime.noffice.api.announcement.presentation.dto.request.AnnouncementCreateRequest;
@@ -43,13 +42,6 @@ public class NotificationService {
 	}
 
 	public void deleteFcmToken(Long memberId, String token) {
-		Member member = memberRepository.findById(memberId).orElseThrow(
-				() -> new NotFoundException(NOT_FOUND_MEMBER)
-		);
-		FcmToken fcmToken = fcmTokenRepository.findByToken(token).orElseThrow(
-				() -> new NotFoundException(NOT_FOUND_FCM_TOKEN)
-		);
-		member.removeFcmToken(fcmToken);
-		fcmTokenRepository.delete(fcmToken);
+		fcmTokenRepository.deleteByMemberIdAndToken(memberId, token);
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/notification/business/NotificationService.java
+++ b/src/main/java/com/notitime/noffice/api/notification/business/NotificationService.java
@@ -1,7 +1,9 @@
 package com.notitime.noffice.api.notification.business;
 
+import static com.notitime.noffice.global.web.BusinessErrorCode.NOT_FOUND_FCM_TOKEN;
 import static com.notitime.noffice.global.web.BusinessErrorCode.NOT_FOUND_MEMBER;
 
+import com.notitime.noffice.api.announcement.presentation.dto.request.AnnouncementCreateRequest;
 import com.notitime.noffice.domain.FcmToken;
 import com.notitime.noffice.domain.announcement.model.Announcement;
 import com.notitime.noffice.domain.announcement.persistence.AnnouncementRepository;
@@ -11,7 +13,6 @@ import com.notitime.noffice.domain.member.persistence.MemberRepository;
 import com.notitime.noffice.domain.notification.model.Notification;
 import com.notitime.noffice.domain.notification.persistence.NotificationRepository;
 import com.notitime.noffice.global.exception.NotFoundException;
-import com.notitime.noffice.api.announcement.presentation.dto.request.AnnouncementCreateRequest;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -39,5 +40,16 @@ public class NotificationService {
 		);
 		FcmToken token = fcmTokenRepository.save(FcmToken.of(member, fcmToken));
 		member.addFcmToken(token);
+	}
+
+	public void deleteFcmToken(Long memberId, String token) {
+		Member member = memberRepository.findById(memberId).orElseThrow(
+				() -> new NotFoundException(NOT_FOUND_MEMBER)
+		);
+		FcmToken fcmToken = fcmTokenRepository.findByToken(token).orElseThrow(
+				() -> new NotFoundException(NOT_FOUND_FCM_TOKEN)
+		);
+		member.removeFcmToken(fcmToken);
+		fcmTokenRepository.delete(fcmToken);
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/notification/presentation/NotificationApi.java
+++ b/src/main/java/com/notitime/noffice/api/notification/presentation/NotificationApi.java
@@ -1,11 +1,13 @@
 package com.notitime.noffice.api.notification.presentation;
 
-import com.notitime.noffice.auth.AuthMember;
-import com.notitime.noffice.global.web.NofficeResponse;
+import com.notitime.noffice.api.notification.presentation.dto.request.DeleteTokenRequest;
+import com.notitime.noffice.api.notification.presentation.dto.request.NotificationBulkRequest;
 import com.notitime.noffice.api.notification.presentation.dto.request.NotificationRequest;
 import com.notitime.noffice.api.notification.presentation.dto.request.NotificationTimeChangeRequest;
-import com.notitime.noffice.api.notification.presentation.dto.request.NotificationBulkRequest;
+import com.notitime.noffice.api.notification.presentation.dto.request.SaveTokenRequest;
 import com.notitime.noffice.api.notification.presentation.dto.response.NotificationTimeChangeResponse;
+import com.notitime.noffice.auth.AuthMember;
+import com.notitime.noffice.global.web.NofficeResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -50,10 +52,17 @@ interface NotificationApi {
 	})
 	NofficeResponse<Void> delete(@PathVariable final Long notificationId);
 
-	@Operation(summary = "기기별 FCM Token 저장", description = "기기별 FCM Token을 저장합니다.", responses = {
+	@Operation(summary = "[인증] 기기별 FCM Token 저장", description = "기기별 FCM Token을 저장합니다.", responses = {
 			@ApiResponse(responseCode = "201", description = "FCM Token 저장 성공"),
 			@ApiResponse(responseCode = "400", description = "FCM Token 저장 실패")
 	})
 	NofficeResponse<Void> saveFcmToken(@Parameter(hidden = true) @AuthMember final Long memberId,
-	                                   @RequestBody final String fcmToken);
+	                                   @RequestBody final SaveTokenRequest fcmToken);
+
+	@Operation(summary = "[인증] 기기별 FCM Token 삭제", description = "기기별 FCM Token을 삭제합니다.", responses = {
+			@ApiResponse(responseCode = "204", description = "FCM Token 삭제 성공"),
+			@ApiResponse(responseCode = "400", description = "FCM Token 삭제 실패")
+	})
+	NofficeResponse<Void> deleteFcmToken(@Parameter(hidden = true) @AuthMember final Long memberId,
+	                                     @RequestBody final DeleteTokenRequest fcmToken);
 }

--- a/src/main/java/com/notitime/noffice/api/notification/presentation/NotificationController.java
+++ b/src/main/java/com/notitime/noffice/api/notification/presentation/NotificationController.java
@@ -8,12 +8,14 @@ import static com.notitime.noffice.global.web.BusinessSuccessCode.OK;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.POST_SAVE_FCM_TOKEN_SUCCESS;
 
 import com.notitime.noffice.api.notification.business.NotificationService;
-import com.notitime.noffice.auth.AuthMember;
-import com.notitime.noffice.global.web.NofficeResponse;
+import com.notitime.noffice.api.notification.presentation.dto.request.DeleteTokenRequest;
+import com.notitime.noffice.api.notification.presentation.dto.request.NotificationBulkRequest;
 import com.notitime.noffice.api.notification.presentation.dto.request.NotificationRequest;
 import com.notitime.noffice.api.notification.presentation.dto.request.NotificationTimeChangeRequest;
-import com.notitime.noffice.api.notification.presentation.dto.request.NotificationBulkRequest;
+import com.notitime.noffice.api.notification.presentation.dto.request.SaveTokenRequest;
 import com.notitime.noffice.api.notification.presentation.dto.response.NotificationTimeChangeResponse;
+import com.notitime.noffice.auth.AuthMember;
+import com.notitime.noffice.global.web.NofficeResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -61,8 +63,15 @@ public class NotificationController implements NotificationApi {
 
 	@PostMapping("/fcm-token")
 	public NofficeResponse<Void> saveFcmToken(@AuthMember final Long memberId,
-	                                          @RequestBody final String fcmToken) {
-		notificationService.saveFcmToken(memberId, fcmToken);
+	                                          @RequestBody final SaveTokenRequest request) {
+		notificationService.saveFcmToken(memberId, request.token());
+		return NofficeResponse.success(POST_SAVE_FCM_TOKEN_SUCCESS);
+	}
+
+	@DeleteMapping("/fcm-token")
+	public NofficeResponse<Void> deleteFcmToken(@AuthMember final Long memberId,
+	                                            @RequestBody final DeleteTokenRequest request) {
+		notificationService.deleteFcmToken(memberId, request.token());
 		return NofficeResponse.success(POST_SAVE_FCM_TOKEN_SUCCESS);
 	}
 }

--- a/src/main/java/com/notitime/noffice/api/notification/presentation/dto/request/DeleteTokenRequest.java
+++ b/src/main/java/com/notitime/noffice/api/notification/presentation/dto/request/DeleteTokenRequest.java
@@ -1,0 +1,10 @@
+package com.notitime.noffice.api.notification.presentation.dto.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record DeleteTokenRequest(
+		@Schema(name = "FCM 토큰", example = "(token)", requiredMode = REQUIRED)
+		String token) {
+}

--- a/src/main/java/com/notitime/noffice/api/notification/presentation/dto/request/SaveTokenRequest.java
+++ b/src/main/java/com/notitime/noffice/api/notification/presentation/dto/request/SaveTokenRequest.java
@@ -1,0 +1,10 @@
+package com.notitime.noffice.api.notification.presentation.dto.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SaveTokenRequest(
+		@Schema(name = "FCM 토큰", example = "(token)", requiredMode = REQUIRED)
+		String token) {
+}

--- a/src/main/java/com/notitime/noffice/domain/RefreshToken.java
+++ b/src/main/java/com/notitime/noffice/domain/RefreshToken.java
@@ -12,6 +12,7 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,6 +20,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "refresh_token")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class RefreshToken {
 
@@ -32,8 +34,18 @@ public class RefreshToken {
 
 	@Enumerated(EnumType.STRING)
 	SocialAuthProvider provider;
-	
+
 	private String refreshToken;
 
 	private LocalDateTime expiredDateTime;
+
+	public static RefreshToken of(Member member, String refreshToken) {
+		return new RefreshToken(
+				null, member, member.getSocialAuthProvider(), refreshToken, LocalDateTime.now().plusDays(30)
+		);
+	}
+
+	public void updateRefreshToken(String refreshToken) {
+		this.refreshToken = refreshToken;
+	}
 }

--- a/src/main/java/com/notitime/noffice/domain/RefreshTokenRepository.java
+++ b/src/main/java/com/notitime/noffice/domain/RefreshTokenRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 	Optional<RefreshToken> findByRefreshToken(String refreshToken);
 
-	void deleteByRefreshToken(String parsedRefreshToken);
+	void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/notitime/noffice/domain/RefreshTokenRepository.java
+++ b/src/main/java/com/notitime/noffice/domain/RefreshTokenRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 	Optional<RefreshToken> findByRefreshToken(String refreshToken);
+
+	void deleteByRefreshToken(String parsedRefreshToken);
 }

--- a/src/main/java/com/notitime/noffice/domain/fcmtoken/persistence/FcmTokenRepository.java
+++ b/src/main/java/com/notitime/noffice/domain/fcmtoken/persistence/FcmTokenRepository.java
@@ -2,22 +2,19 @@ package com.notitime.noffice.domain.fcmtoken.persistence;
 
 import com.notitime.noffice.domain.FcmToken;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
-	Optional<FcmToken> findByToken(String token);
 
 	List<FcmToken> findByMemberId(Long memberId);
-
-	void deleteByToken(String value);
 
 	@Query("SELECT f.token FROM FcmToken f WHERE f.member.id IN :newMemberIds")
 	List<String> findAllTokenByMemberIdIn(List<Long> newMemberIds);
 
-	//	@Modifying
-//	@Query("DELETE FROM FcmToken f WHERE f.member.id = :memberId AND f.token = :token")
+	@Modifying
+	@Query("DELETE FROM FcmToken f WHERE f.member.id = :memberId AND f.token = :token")
 	void deleteByMemberIdAndToken(Long memberId, String token);
 
 	void deleteByMemberId(Long memberId);

--- a/src/main/java/com/notitime/noffice/domain/fcmtoken/persistence/FcmTokenRepository.java
+++ b/src/main/java/com/notitime/noffice/domain/fcmtoken/persistence/FcmTokenRepository.java
@@ -15,4 +15,10 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 
 	@Query("SELECT f.token FROM FcmToken f WHERE f.member.id IN :newMemberIds")
 	List<String> findAllTokenByMemberIdIn(List<Long> newMemberIds);
+
+	//	@Modifying
+//	@Query("DELETE FROM FcmToken f WHERE f.member.id = :memberId AND f.token = :token")
+	void deleteByMemberIdAndToken(Long memberId, String token);
+
+	void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/notitime/noffice/domain/member/model/Member.java
+++ b/src/main/java/com/notitime/noffice/domain/member/model/Member.java
@@ -103,4 +103,8 @@ public class Member extends BaseTimeEntity {
 	public void updateProfileImage(String imageUrl) {
 		this.profileImage = imageUrl;
 	}
+
+	public void removeFcmToken(FcmToken fcmToken) {
+		this.fcmTokens.remove(fcmToken);
+	}
 }

--- a/src/main/java/com/notitime/noffice/global/web/BusinessErrorCode.java
+++ b/src/main/java/com/notitime/noffice/global/web/BusinessErrorCode.java
@@ -45,6 +45,7 @@ public enum BusinessErrorCode implements ErrorCode {
 	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "NOF-4470", "멤버를 찾을 수 없습니다."),
 	NOT_FOUND_ORGANIZATION(HttpStatus.NOT_FOUND, "NOF-4480", "조직을 찾을 수 없습니다."),
 	NOT_FOUND_PROMOTION(HttpStatus.NOT_FOUND, "NOF-4490", "프로모션을 찾을 수 없습니다."),
+	NOT_FOUND_FCM_TOKEN(HttpStatus.NOT_FOUND, "NOF-4491", "FCM 토큰을 찾을 수 없습니다."),
 	STORE_FILE_SIZE_EXCEEDED(HttpStatus.NOT_FOUND, "NOF-404", "업로드 가능한 파일 크기를 초과했습니다."),
 
 	// 500 Internal Server Error

--- a/src/main/java/com/notitime/noffice/global/web/BusinessSuccessCode.java
+++ b/src/main/java/com/notitime/noffice/global/web/BusinessSuccessCode.java
@@ -13,6 +13,7 @@ public enum BusinessSuccessCode implements SuccessCode {
 	POST_LOGIN_SUCCESS(HttpStatus.OK, "NOF-2000", "로그인에 성공하였습니다."),
 	POST_REISSUE_SUCCESS(HttpStatus.OK, "NOF-2000", "액세스 토큰 재발급에 성공하였습니다."),
 	POST_LOGOUT_SUCCESS(HttpStatus.OK, "NOF-2000", "로그아웃에 성공하였습니다."),
+	POST_WITHDRAWAL_SUCCESS(HttpStatus.OK, "NOF-2000", "회원 탈퇴에 성공하였습니다."),
 	GET_MEMBER_SUCCESS(HttpStatus.OK, "NOF-2001", "회원 정보 조회에 성공하였습니다."),
 	GET_JOINED_ORGANIZATIONS_SUCCESS(HttpStatus.OK, "NOF-2002", "회원의 가입된 조직 조회에 성공하였습니다."),
 	GET_ORGANIZATION_SUCCESS(HttpStatus.OK, "NOF-2003", "조직 정보 조회에 성공하였습니다."),


### PR DESCRIPTION
## 🚀 Related Issue

close: #92 

## 📌 Tasks

- [Feat] 회원 탈퇴 및 로그아웃, JWT 재발급 로직 개선

## 📝 Details

- 로그인 완료 시 리프레시 토큰을 별도 테이블에 저장하는 로직 추가
 - TODO:  외부 서버를 통해 조회하지 않아도 되는 기능이므로, in-memory db에서 참조하는 방식으로 변경 가능 
1. **회원 로그아웃** 기능
 - `POST` | /api/v1/member/logout
  - `requestHeader` : `notification-token` (로그아웃을 요청한 기기의 fcm 토큰)
 - **수행 동작** : 등록된 리프레시토큰 및 요청 **기기의 단일 알림 토큰을 삭제**

2. **회원 탈퇴** 기능
 - `DELETE` | /api/v1/member/withdrawal 
 - **수행 동작** : 등록된 리프레시토큰 및 **요청 기기의 모든 알림 토큰을 삭제**

## 📚 Remarks

- 
- 