### PR TITLE
📝 [Docs] Fcm token 관련 API typo missing 수정

### DIFF
--- a/src/main/java/com/notitime/noffice/api/notification/presentation/dto/request/DeleteTokenRequest.java
+++ b/src/main/java/com/notitime/noffice/api/notification/presentation/dto/request/DeleteTokenRequest.java
@@ -5,6 +5,6 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record DeleteTokenRequest(
-		@Schema(name = "FCM 토큰", example = "(token)", requiredMode = REQUIRED)
+		@Schema(description = "FCM 토큰", example = "token", requiredMode = REQUIRED)
 		String token) {
 }

--- a/src/main/java/com/notitime/noffice/api/notification/presentation/dto/request/SaveTokenRequest.java
+++ b/src/main/java/com/notitime/noffice/api/notification/presentation/dto/request/SaveTokenRequest.java
@@ -5,6 +5,6 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record SaveTokenRequest(
-		@Schema(name = "FCM 토큰", example = "(token)", requiredMode = REQUIRED)
+		@Schema(description = "FCM 토큰", example = "token", requiredMode = REQUIRED)
 		String token) {
 }


### PR DESCRIPTION
## 🚀 Related Issue

close: #

## 📌 Tasks

- Fcm token 관련 API typo missing 수정

## 📝 Details

- expected value
```json
{
  "token" : "value" // string
}
```

## 📚 Remarks

<img width="129" alt="스크린샷 2024-08-29 오후 2 32 32" src="https://github.com/user-attachments/assets/21353ef4-a41c-4eb2-adde-72fbf0013e3f">