### PR TITLE
✨ [Feat] 카카오 로그인

### DIFF
--- a/src/main/java/com/notitime/noffice/api/auth/business/strategy/AppleAuthStrategy.java
+++ b/src/main/java/com/notitime/noffice/api/auth/business/strategy/AppleAuthStrategy.java
@@ -14,7 +14,7 @@ import com.notitime.noffice.external.openfeign.apple.AppleIdentityTokenParser;
 import com.notitime.noffice.external.openfeign.apple.AppleOAuthProvider;
 import com.notitime.noffice.external.openfeign.apple.ApplePublicKeyGenerator;
 import com.notitime.noffice.external.openfeign.apple.dto.ApplePublicKeys;
-import com.notitime.noffice.external.openfeign.dto.AuthorizedMemberInfo;
+import com.notitime.noffice.external.openfeign.apple.dto.AuthorizedMemberInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/notitime/noffice/api/auth/business/strategy/AppleAuthStrategy.java
+++ b/src/main/java/com/notitime/noffice/api/auth/business/strategy/AppleAuthStrategy.java
@@ -17,10 +17,10 @@ import com.notitime.noffice.external.openfeign.apple.dto.ApplePublicKeys;
 import com.notitime.noffice.external.openfeign.dto.AuthorizedMemberInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Component
+@Service
 @RequiredArgsConstructor
 public class AppleAuthStrategy implements SocialAuthStrategy {
 

--- a/src/main/java/com/notitime/noffice/api/auth/business/strategy/GoogleAuthStrategy.java
+++ b/src/main/java/com/notitime/noffice/api/auth/business/strategy/GoogleAuthStrategy.java
@@ -23,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class GoogleAuthStrategy implements SocialAuthStrategy {
 
-	private final RefreshTokenRepository refreshTokenRepository;
 	@Value("${oauth.google.client-id}")
 	private String googleClientId;
 	@Value("${oauth.google.client-secret}")
@@ -38,6 +37,7 @@ public class GoogleAuthStrategy implements SocialAuthStrategy {
 
 	private final JwtProvider jwtProvider;
 	private final MemberRepository memberRepository;
+	private final RefreshTokenRepository refreshTokenRepository;
 
 	@Override
 	public boolean support(SocialAuthProvider provider) {

--- a/src/main/java/com/notitime/noffice/api/auth/business/strategy/KakaoAuthStrategy.java
+++ b/src/main/java/com/notitime/noffice/api/auth/business/strategy/KakaoAuthStrategy.java
@@ -1,0 +1,58 @@
+package com.notitime.noffice.api.auth.business.strategy;
+
+import com.notitime.noffice.api.auth.presentation.dto.request.SocialAuthRequest;
+import com.notitime.noffice.api.auth.presentation.dto.response.SocialAuthResponse;
+import com.notitime.noffice.api.auth.presentation.dto.response.TokenResponse;
+import com.notitime.noffice.auth.jwt.JwtProvider;
+import com.notitime.noffice.domain.RefreshToken;
+import com.notitime.noffice.domain.RefreshTokenRepository;
+import com.notitime.noffice.domain.SocialAuthProvider;
+import com.notitime.noffice.domain.member.model.Member;
+import com.notitime.noffice.domain.member.persistence.MemberRepository;
+import com.notitime.noffice.external.openfeign.kakao.KakaoUserInfoClient;
+import com.notitime.noffice.external.openfeign.kakao.dto.KakaoUserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoAuthStrategy implements SocialAuthStrategy {
+
+	@Value("${oauth.kakao.client-id}")
+	private String kakaoClientId;
+	@Value("${oauth.kakao.client-secret}")
+	private String kakaoClientSecret;
+
+	private final KakaoUserInfoClient kakaoUserInfoClient;
+
+	private final JwtProvider jwtProvider;
+	private final MemberRepository memberRepository;
+	private final RefreshTokenRepository refreshTokenRepository;
+
+	@Override
+	public boolean support(SocialAuthProvider provider) {
+		return provider.equals(SocialAuthProvider.KAKAO);
+	}
+
+	@Override
+	public SocialAuthResponse login(SocialAuthRequest request) {
+		// TODO: revise Access token to OIDC token
+		KakaoUserResponse userResponse = kakaoUserInfoClient.getUserInformation("Bearer " + request.code());
+		Boolean isAlreadyMember = memberRepository.existsBySerialId(userResponse.id());
+		Member member = memberRepository.findBySerialId(userResponse.id())
+				.orElseGet(() -> Member.createAuthorizedMember(
+						userResponse.id(),
+						userResponse.kakaoAccount().profile().nickname(),
+						null,
+						request.provider(),
+						userResponse.kakaoAccount().profile().profileImageUrl()));
+		memberRepository.save(member);
+		TokenResponse tokenResponse = TokenResponse.toResponse(jwtProvider.issueTokens(member.getId()));
+		if (!isAlreadyMember) {
+			refreshTokenRepository.save(RefreshToken.of(member, tokenResponse.refreshToken()));
+		}
+		return SocialAuthResponse.of(member.getId(), member.getName(), request.provider(), isAlreadyMember,
+				tokenResponse);
+	}
+}

--- a/src/main/java/com/notitime/noffice/api/auth/business/strategy/SocialAuthContext.java
+++ b/src/main/java/com/notitime/noffice/api/auth/business/strategy/SocialAuthContext.java
@@ -1,10 +1,10 @@
 package com.notitime.noffice.api.auth.business.strategy;
 
+import com.notitime.noffice.api.auth.presentation.dto.request.SocialAuthRequest;
+import com.notitime.noffice.api.auth.presentation.dto.response.SocialAuthResponse;
 import com.notitime.noffice.domain.SocialAuthProvider;
 import com.notitime.noffice.global.exception.BadRequestException;
 import com.notitime.noffice.global.web.BusinessErrorCode;
-import com.notitime.noffice.api.auth.presentation.dto.request.SocialAuthRequest;
-import com.notitime.noffice.api.auth.presentation.dto.response.SocialAuthResponse;
 import jakarta.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,12 +17,14 @@ public class SocialAuthContext {
 
 	private final GoogleAuthStrategy googleAuthStrategy;
 	private final AppleAuthStrategy appleAuthStrategy;
+	private final KakaoAuthStrategy kakaoAuthStrategy;
 	private final List<SocialAuthStrategy> socialAuthStrategies = new ArrayList<>();
 
 	@PostConstruct
 	void initSocialLoginContext() {
 		socialAuthStrategies.add(appleAuthStrategy);
 		socialAuthStrategies.add(googleAuthStrategy);
+		socialAuthStrategies.add(kakaoAuthStrategy);
 	}
 
 	public boolean support(SocialAuthProvider provider) {

--- a/src/main/java/com/notitime/noffice/domain/SocialAuthProvider.java
+++ b/src/main/java/com/notitime/noffice/domain/SocialAuthProvider.java
@@ -1,5 +1,5 @@
 package com.notitime.noffice.domain;
 
 public enum SocialAuthProvider {
-	GOOGLE, APPLE
+	GOOGLE, APPLE, KAKAO
 }

--- a/src/main/java/com/notitime/noffice/external/openfeign/apple/AppleOAuthProvider.java
+++ b/src/main/java/com/notitime/noffice/external/openfeign/apple/AppleOAuthProvider.java
@@ -1,7 +1,7 @@
 package com.notitime.noffice.external.openfeign.apple;
 
 import com.notitime.noffice.external.openfeign.apple.dto.ApplePublicKeys;
-import com.notitime.noffice.external.openfeign.dto.AuthorizedMemberInfo;
+import com.notitime.noffice.external.openfeign.apple.dto.AuthorizedMemberInfo;
 import io.jsonwebtoken.Claims;
 import java.security.PublicKey;
 import java.util.Map;

--- a/src/main/java/com/notitime/noffice/external/openfeign/apple/dto/AuthorizedMemberInfo.java
+++ b/src/main/java/com/notitime/noffice/external/openfeign/apple/dto/AuthorizedMemberInfo.java
@@ -1,4 +1,4 @@
-package com.notitime.noffice.external.openfeign.dto;
+package com.notitime.noffice.external.openfeign.apple.dto;
 
 public record AuthorizedMemberInfo(
 		String serialId,

--- a/src/main/java/com/notitime/noffice/external/openfeign/kakao/KakaoUserInfoClient.java
+++ b/src/main/java/com/notitime/noffice/external/openfeign/kakao/KakaoUserInfoClient.java
@@ -1,0 +1,14 @@
+package com.notitime.noffice.external.openfeign.kakao;
+
+import com.notitime.noffice.external.openfeign.kakao.dto.KakaoUserResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "kakaoUserInfoClient", url = "https://kapi.kakao.com")
+public interface KakaoUserInfoClient {
+
+	@GetMapping(value = "/v2/user/me")
+	KakaoUserResponse getUserInformation(@RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken);
+}

--- a/src/main/java/com/notitime/noffice/external/openfeign/kakao/dto/KakaoAccount.java
+++ b/src/main/java/com/notitime/noffice/external/openfeign/kakao/dto/KakaoAccount.java
@@ -1,0 +1,6 @@
+package com.notitime.noffice.external.openfeign.kakao.dto;
+
+public record KakaoAccount(
+		KakaoUserProfile profile
+) {
+}

--- a/src/main/java/com/notitime/noffice/external/openfeign/kakao/dto/KakaoUserProfile.java
+++ b/src/main/java/com/notitime/noffice/external/openfeign/kakao/dto/KakaoUserProfile.java
@@ -1,0 +1,7 @@
+package com.notitime.noffice.external.openfeign.kakao.dto;
+
+public record KakaoUserProfile(
+		String nickname,
+		String profileImageUrl
+) {
+}

--- a/src/main/java/com/notitime/noffice/external/openfeign/kakao/dto/KakaoUserResponse.java
+++ b/src/main/java/com/notitime/noffice/external/openfeign/kakao/dto/KakaoUserResponse.java
@@ -1,0 +1,7 @@
+package com.notitime.noffice.external.openfeign.kakao.dto;
+
+public record KakaoUserResponse(
+		String id,
+		KakaoAccount kakaoAccount
+) {
+}


### PR DESCRIPTION
## 🚀 Related Issue

close: #161 

## 📌 Tasks

- 카카오 로그인 기능
- Google, Apple 로그인 구현부 기존 컨벤션 반영

## 📝 Details

- 기존 로그인 API와 동일한 endpoint를 사용합니다.

## 📚 Remarks

- access token으로 로그인을 시도합니다.
- 탈취 위험이 있으므로, PKCE 보안이 적용된 OIDC로 전환해야 합니다.