### PR TITLE
[Refactor] 사용자 소유 별칭 조직별 관리로 분리

### DIFF
--- a/src/main/java/com/notitime/noffice/api/member/business/MemberService.java
+++ b/src/main/java/com/notitime/noffice/api/member/business/MemberService.java
@@ -1,6 +1,5 @@
 package com.notitime.noffice.api.member.business;
 
-import com.notitime.noffice.api.member.presentation.dto.request.MemberAliasUpdateRequest;
 import com.notitime.noffice.api.member.presentation.dto.request.MemberProfileUpdateRequest;
 import com.notitime.noffice.api.member.presentation.dto.response.MemberResponse;
 import com.notitime.noffice.domain.member.model.Member;
@@ -25,12 +24,6 @@ public class MemberService {
 	public void deleteProfileImage(Long memberId) {
 		Member member = findById(memberId);
 		member.deleteProfileImage();
-		memberRepository.save(member);
-	}
-
-	public void updateAlias(Long memberId, MemberAliasUpdateRequest request) {
-		Member member = findById(memberId);
-		member.updateAlias(request.alias());
 		memberRepository.save(member);
 	}
 

--- a/src/main/java/com/notitime/noffice/api/member/presentation/MemberController.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/MemberController.java
@@ -68,10 +68,10 @@ public class MemberController implements MemberApi {
 		return NofficeResponse.success(GET_MEMBER_SUCCESS, memberService.getMember(memberId));
 	}
 
+	@Deprecated(forRemoval = true)
 	@PatchMapping("/alias")
 	public NofficeResponse<Void> updateAlias(@AuthMember final Long memberId,
 	                                         @RequestBody final MemberAliasUpdateRequest alias) {
-		memberService.updateAlias(memberId, alias);
 		return NofficeResponse.success(PATCH_UPDATE_ALIAS_SUCCESS);
 	}
 

--- a/src/main/java/com/notitime/noffice/api/member/presentation/dto/response/MemberInfoResponse.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/dto/response/MemberInfoResponse.java
@@ -7,7 +7,7 @@ public record MemberInfoResponse(Long id, String name, String alias, String prof
 		return new MemberInfoResponse(
 				member.getId(),
 				member.getName(),
-				member.getAlias(),
+				member.getName(),
 				member.getProfileImage()
 		);
 	}

--- a/src/main/java/com/notitime/noffice/api/member/presentation/dto/response/MemberResponse.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/dto/response/MemberResponse.java
@@ -11,7 +11,7 @@ public record MemberResponse(Long id, String name, String alias, String profileI
 		return new MemberResponse(
 				member.getId(),
 				member.getName(),
-				member.getAlias(),
+				member.getName(),
 				member.getProfileImage(),
 				OrganizationResponses.from(member.getOrganizations()).organizations()
 		);

--- a/src/main/java/com/notitime/noffice/api/organization/business/OrganizationService.java
+++ b/src/main/java/com/notitime/noffice/api/organization/business/OrganizationService.java
@@ -79,7 +79,11 @@ public class OrganizationService {
 	}
 
 	public OrganizationCreateResponse create(Long createMemberId, OrganizationCreateRequest request) {
-		return OrganizationCreateResponse.of(organizationRepository.save(createByRequest(createMemberId, request)));
+		List<Category> categories = categoryRepository.findByIdIn(request.categoryList());
+		Member leader = getMemberEntity(createMemberId);
+		Organization organization = Organization.create(request.name(), request.endAt(), request.profileImage(),
+				categories, leader);
+		return OrganizationCreateResponse.of(organizationRepository.save(organization));
 	}
 
 	public OrganizationJoinResponse join(Long memberId, Long organizationId) {
@@ -193,12 +197,6 @@ public class OrganizationService {
 
 	private Boolean isAnyMemberPending(Long organizationId) {
 		return organizationMemberRepository.existsByOrganizationIdAndStatus(organizationId, JoinStatus.PENDING);
-	}
-
-	private Organization createByRequest(Long createMemberId, OrganizationCreateRequest request) {
-		List<Category> categories = categoryRepository.findByIdIn(request.categoryList());
-		Member leader = getMemberEntity(createMemberId);
-		return Organization.create(request.name(), request.endAt(), request.profileImage(), categories, leader);
 	}
 
 	public OrganizationMemberResponses getRegisteredMembers(Long requesterMemberId, Long organizationId) {

--- a/src/main/java/com/notitime/noffice/api/organization/business/OrganizationService.java
+++ b/src/main/java/com/notitime/noffice/api/organization/business/OrganizationService.java
@@ -85,7 +85,7 @@ public class OrganizationService {
 	public OrganizationJoinResponse join(Long memberId, Long organizationId) {
 		Organization organization = getOrganizationEntity(organizationId);
 		Member member = getMemberEntity(memberId);
-		organizationMemberRepository.save(OrganizationMember.join(organization, member));
+		organizationMemberRepository.save(OrganizationMember.addPendingList(organization, member));
 		return OrganizationJoinResponse.from(organization, member);
 	}
 

--- a/src/main/java/com/notitime/noffice/domain/member/model/Member.java
+++ b/src/main/java/com/notitime/noffice/domain/member/model/Member.java
@@ -43,8 +43,6 @@ public class Member extends BaseTimeEntity {
 	@Column(nullable = false)
 	private String name;
 
-	private String alias;
-
 	private String serialId;
 
 	@Column(columnDefinition = "TEXT")
@@ -74,7 +72,6 @@ public class Member extends BaseTimeEntity {
 		return Member.builder()
 				.serialId(serialId)
 				.name(name)
-				.alias(name)
 				.email(email)
 				.socialAuthProvider(socialAuthProvider)
 				.profileImage(profileImage)
@@ -94,10 +91,6 @@ public class Member extends BaseTimeEntity {
 
 	public void deleteProfileImage() {
 		this.profileImage = null;
-	}
-
-	public void updateAlias(String alias) {
-		this.alias = alias;
 	}
 
 	public void updateProfileImage(String imageUrl) {

--- a/src/main/java/com/notitime/noffice/domain/organization/model/Nickname.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/model/Nickname.java
@@ -1,0 +1,27 @@
+package com.notitime.noffice.domain.organization.model;
+
+import com.notitime.noffice.global.exception.BadRequestException;
+import com.notitime.noffice.global.web.BusinessErrorCode;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Nickname {
+
+	private static final int MAX_LENGTH = 10;
+
+	private String nickname;
+
+	public Nickname(String nickname) {
+		validate(nickname);
+		this.nickname = nickname;
+	}
+
+	private void validate(final String nickname) {
+		if (nickname.length() > MAX_LENGTH) {throw new BadRequestException(BusinessErrorCode.INVALID_NICKNAME_LENGTH);}
+	}
+}

--- a/src/main/java/com/notitime/noffice/domain/organization/model/Organization.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/model/Organization.java
@@ -80,7 +80,7 @@ public class Organization extends BaseTimeEntity {
 	}
 
 	private void addLeader(Member leader) {
-		this.members.add(OrganizationMember.create(this, leader));
+		this.members.add(OrganizationMember.joinAsLeader(this, leader));
 	}
 
 	public void addAnnouncement(Announcement announcement) {

--- a/src/main/java/com/notitime/noffice/domain/organization/model/Organization.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/model/Organization.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,6 +25,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Organization extends BaseTimeEntity {
 
 	@Id

--- a/src/main/java/com/notitime/noffice/domain/organization/model/Organization.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/model/Organization.java
@@ -80,7 +80,8 @@ public class Organization extends BaseTimeEntity {
 	}
 
 	private void addLeader(Member leader) {
-		this.members.add(OrganizationMember.joinAsLeader(this, leader));
+		Nickname nickname = new Nickname(leader.getName());
+		this.members.add(OrganizationMember.joinAsLeader(nickname, this, leader));
 	}
 
 	public void addAnnouncement(Announcement announcement) {

--- a/src/main/java/com/notitime/noffice/domain/organization/model/OrganizationCategory.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/model/OrganizationCategory.java
@@ -10,7 +10,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,7 +21,6 @@ import lombok.NoArgsConstructor;
 		}
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class OrganizationCategory {
 

--- a/src/main/java/com/notitime/noffice/domain/organization/model/OrganizationMember.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/model/OrganizationMember.java
@@ -55,7 +55,7 @@ public class OrganizationMember extends BaseTimeEntity {
 		return new OrganizationMember(null, null, PARTICIPANT, PENDING, organization, member);
 	}
 
-	public static OrganizationMember joinAsLeader(Organization organization, Member member) {
-		return new OrganizationMember(null, null, LEADER, ACTIVE, organization, member);
+	public static OrganizationMember joinAsLeader(Nickname nickname, Organization organization, Member member) {
+		return new OrganizationMember(null, nickname, LEADER, ACTIVE, organization, member);
 	}
 }

--- a/src/main/java/com/notitime/noffice/domain/organization/model/OrganizationMember.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/model/OrganizationMember.java
@@ -9,6 +9,7 @@ import com.notitime.noffice.domain.BaseTimeEntity;
 import com.notitime.noffice.domain.JoinStatus;
 import com.notitime.noffice.domain.OrganizationRole;
 import com.notitime.noffice.domain.member.model.Member;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -33,6 +34,9 @@ public class OrganizationMember extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Embedded
+	private Nickname nickname;
+
 	@Enumerated(EnumType.STRING)
 	private OrganizationRole role;
 
@@ -47,29 +51,11 @@ public class OrganizationMember extends BaseTimeEntity {
 	@JoinColumn(name = "member_id")
 	private Member member;
 
-	public static OrganizationMember join(Organization organization, Member member) {
-		OrganizationMember organizationMember = new OrganizationMember(null, PARTICIPANT, PENDING,
-				organization, member);
-		organizationMember.setOrganization(organization);
-		organizationMember.setMember(member);
-		return organizationMember;
+	public static OrganizationMember addPendingList(Organization organization, Member member) {
+		return new OrganizationMember(null, null, PARTICIPANT, PENDING, organization, member);
 	}
 
-	public static OrganizationMember create(Organization organization, Member member) {
-		return new OrganizationMember(null, LEADER, ACTIVE, organization, member);
-	}
-
-	public void setOrganization(Organization organization) {
-		this.organization = organization;
-		if (!organization.getMembers().contains(this)) {
-			organization.getMembers().add(this);
-		}
-	}
-
-	public void setMember(Member member) {
-		this.member = member;
-		if (!member.getOrganizations().contains(this)) {
-			member.getOrganizations().add(this);
-		}
+	public static OrganizationMember joinAsLeader(Organization organization, Member member) {
+		return new OrganizationMember(null, null, LEADER, ACTIVE, organization, member);
 	}
 }

--- a/src/main/java/com/notitime/noffice/domain/organization/model/OrganizationMember.java
+++ b/src/main/java/com/notitime/noffice/domain/organization/model/OrganizationMember.java
@@ -55,7 +55,7 @@ public class OrganizationMember extends BaseTimeEntity {
 		return new OrganizationMember(null, null, PARTICIPANT, PENDING, organization, member);
 	}
 
-	public static OrganizationMember joinAsLeader(Nickname nickname, Organization organization, Member member) {
-		return new OrganizationMember(null, nickname, LEADER, ACTIVE, organization, member);
+	public static OrganizationMember joinAsLeader(String nickname, Organization organization, Member member) {
+		return new OrganizationMember(null, new Nickname(nickname), LEADER, ACTIVE, organization, member);
 	}
 }

--- a/src/main/java/com/notitime/noffice/global/web/BusinessErrorCode.java
+++ b/src/main/java/com/notitime/noffice/global/web/BusinessErrorCode.java
@@ -17,6 +17,7 @@ public enum BusinessErrorCode implements ErrorCode {
 	APPLE_FEIGN_CONNECT_ERROR(HttpStatus.BAD_REQUEST, "NOF-4011", "Apple auth Feign 연결 중 오류가 발생했습니다."),
 	GOOGLE_FEIGN_CONNECT_ERROR(HttpStatus.BAD_REQUEST, "NOF-4012", "Google auth Feign 연결 중 오류가 발생했습니다."),
 	NOT_SUPPORTED_LOGIN_PLATFORM(HttpStatus.BAD_REQUEST, "NOF-400", "지원되지 않는 로그인 플랫폼입니다."),
+	INVALID_NICKNAME_LENGTH(HttpStatus.BAD_REQUEST, "NOF-400", "닉네임의 허용 길이를 초과했습니다."),
 
 	// 401 Unauthorized
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "NOF-401", "리소스 접근 권한이 없습니다."),

--- a/src/main/java/com/notitime/noffice/global/web/BusinessSuccessCode.java
+++ b/src/main/java/com/notitime/noffice/global/web/BusinessSuccessCode.java
@@ -56,7 +56,7 @@ public enum BusinessSuccessCode implements SuccessCode {
 	DELETE_PROFILE_IMAGE_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2402", "프로필 이미지 삭제 성공"),
 	PATCH_MODIFY_COVER_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2403", "공지 커버 이미지 수정 성공"),
 	PATCH_UPDATE_TASK_STATUS_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2404", "사용자 투두 리스트 업데이트 성공"),
-	PATCH_UPDATE_ALIAS_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2405", "회원 별명 변경 성공"),
+	PATCH_UPDATE_ALIAS_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2405", "[비활성화 대상] 회원 별명 변경 성공"),
 	PATCH_UPDATE_PROFILE_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2406", "프로필 이미지 주소 변경 성공"),
 
 	// RESET CONTENT (2500 ~ 2599)


### PR DESCRIPTION
## 🚀 Related Issue

close: #165 

## 📌 Tasks

- 사용자의 조직별 닉네임 설정 기능 추가 (닉네임 설정 시점에 10자 제한 검증 수행)
- 기존 단일 사용자 정보에 부여된 닉네임 필드 제거
  - 관련 API 비활성화 및 필드 수정

## 📝 Details

- 조직 관련 생성 로직 정적 팩토리 메소드로 리팩토링 수행

## 📚 Remarks

- 사용자 조회 응답에 바인딩된 닉네임 필드 (Member.alias)는 client 수정 후 삭제