### PR TITLE
[Refactor] 게시글 열람 상태 기록 로직 리팩토링

### DIFF
--- a/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
@@ -15,6 +15,7 @@ import com.notitime.noffice.api.notification.business.NotificationService;
 import com.notitime.noffice.api.organization.business.RoleVerifier;
 import com.notitime.noffice.api.task.business.TaskStatusManager;
 import com.notitime.noffice.domain.announcement.model.Announcement;
+import com.notitime.noffice.domain.announcement.persistence.AnnouncementReadStatusRepository;
 import com.notitime.noffice.domain.announcement.persistence.AnnouncementRepository;
 import com.notitime.noffice.domain.member.model.Member;
 import com.notitime.noffice.domain.member.persistence.MemberRepository;
@@ -35,17 +36,19 @@ import org.springframework.transaction.annotation.Transactional;
 public class AnnouncementService {
 
 	private final AnnouncementRepository announcementRepository;
+	private final AnnouncementReadStatusRepository announcementReadStatusRepository;
 	private final MemberRepository memberRepository;
 	private final OrganizationRepository organizationRepository;
+
 	private final NotificationService notificationService;
-	private final RoleVerifier roleVerifier;
 	private final ReadStatusRecoder readStatusRecoder;
-	private final FcmService fcmService;
 	private final TaskStatusManager taskStatusManager;
+	private final RoleVerifier roleVerifier;
+	private final FcmService fcmService;
 
 	public AnnouncementResponse read(Long memberId, Long announcementId) {
 		roleVerifier.verifyJoinedMember(memberId, getOrganizationId(announcementId));
-		recordReadStatus(memberId, announcementId);
+		readStatusRecoder.recordMemberRead(memberId, announcementId);
 		return AnnouncementResponse.of(announcementRepository.findById(announcementId)
 				.orElseThrow(() -> new NotFoundException(NOT_FOUND_ANNOUNCEMENT)));
 	}
@@ -78,7 +81,7 @@ public class AnnouncementService {
 	public Slice<AnnouncementCoverResponse> getPublishedAnnouncements(Long organizationId, Pageable pageable) {
 		return announcementRepository.findByOrganizationId(organizationId, pageable)
 				.map(announcement -> {
-					Long readCount = readStatusRecoder.countReader(announcement.getId());
+					Long readCount = announcementReadStatusRepository.countByAnnouncementId(announcement.getId());
 					Long totalMemberCount = getTotalMemberCount(organizationId);
 					return AnnouncementCoverResponse.of(announcement, readCount, totalMemberCount);
 				});
@@ -96,9 +99,7 @@ public class AnnouncementService {
 		roleVerifier.verifyJoinedMember(memberId, organizationId);
 		Announcement announcement = announcementRepository.findById(announcementId)
 				.orElseThrow(() -> new NotFoundException(NOT_FOUND_ANNOUNCEMENT));
-		Organization organization = organizationRepository.findById(organizationId)
-				.orElseThrow(() -> new NotFoundException(NOT_FOUND_ORGANIZATION));
-		List<Member> unreadMembers = readStatusRecoder.findUnReadMembers(announcement, organization);
+		List<Member> unreadMembers = announcementReadStatusRepository.findUnReadMembers(announcement.getId());
 		return ReadStatusResponse.of(announcementId, unreadMembers.stream()
 				.map(MemberInfoResponse::from)
 				.toList());
@@ -126,14 +127,6 @@ public class AnnouncementService {
 		taskStatusManager.assignTasks(organization, announcement);
 		organization.addAnnouncement(announcement);
 		return announcement;
-	}
-
-	private void recordReadStatus(Long memberId, Long announcementId) {
-		Member member = memberRepository.findById(memberId)
-				.orElseThrow(() -> new NotFoundException(NOT_FOUND_MEMBER));
-		Announcement announcement = announcementRepository.findById(announcementId)
-				.orElseThrow(() -> new NotFoundException(NOT_FOUND_ANNOUNCEMENT));
-		readStatusRecoder.record(member, announcement);
 	}
 
 	private Long getTotalMemberCount(Long organizationId) {

--- a/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
@@ -88,15 +88,13 @@ public class AnnouncementService {
 	}
 
 	public ReadStatusResponse getReadMembers(Long memberId, Long announcementId) {
-		roleVerifier.verifyJoinedMember(memberId, getOrganizationId(announcementId));
-		return ReadStatusResponse.of(announcementId, readStatusRecoder.findReadMembers(announcementId).stream()
+		List<MemberInfoResponse> members = announcementReadStatusRepository.findReadMembers(announcementId).stream()
 				.map(MemberInfoResponse::from)
-				.toList());
+				.toList();
+		return ReadStatusResponse.of(announcementId, members);
 	}
 
 	public ReadStatusResponse getUnreadMembers(Long memberId, Long announcementId) {
-		Long organizationId = getOrganizationId(announcementId);
-		roleVerifier.verifyJoinedMember(memberId, organizationId);
 		Announcement announcement = announcementRepository.findById(announcementId)
 				.orElseThrow(() -> new NotFoundException(NOT_FOUND_ANNOUNCEMENT));
 		List<Member> unreadMembers = announcementReadStatusRepository.findUnReadMembers(announcement.getId());

--- a/src/main/java/com/notitime/noffice/api/announcement/business/ReadStatusRecoder.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/business/ReadStatusRecoder.java
@@ -1,16 +1,15 @@
 package com.notitime.noffice.api.announcement.business;
 
-import com.notitime.noffice.domain.JoinStatus;
+import static com.notitime.noffice.global.web.BusinessErrorCode.NOT_FOUND_ANNOUNCEMENT;
+import static com.notitime.noffice.global.web.BusinessErrorCode.NOT_FOUND_MEMBER;
+
 import com.notitime.noffice.domain.announcement.model.Announcement;
 import com.notitime.noffice.domain.announcement.model.AnnouncementReadStatus;
 import com.notitime.noffice.domain.announcement.persistence.AnnouncementReadStatusRepository;
 import com.notitime.noffice.domain.announcement.persistence.AnnouncementRepository;
 import com.notitime.noffice.domain.member.model.Member;
-import com.notitime.noffice.domain.organization.model.Organization;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import com.notitime.noffice.domain.member.persistence.MemberRepository;
+import com.notitime.noffice.global.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,42 +21,19 @@ public class ReadStatusRecoder {
 
 	private final AnnouncementReadStatusRepository announcementReadStatusRepository;
 	private final AnnouncementRepository announcementRepository;
+	private final MemberRepository memberRepository;
 
-	public void record(Member member, Announcement announcement) {
-		boolean isAlreadyRead = announcementReadStatusRepository.existsByMemberIdAndAnnouncementId(member.getId(),
-				announcement.getId());
-		if (!isAlreadyRead) {
-			announcementReadStatusRepository.save(AnnouncementReadStatus.builder()
-					.readAt(LocalDateTime.now())
-					.isRead(true)
-					.member(member)
-					.announcement(announcement)
-					.build());
+	public void recordMemberRead(Long memberId, Long announcementId) {
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> new NotFoundException(NOT_FOUND_MEMBER));
+		Announcement announcement = announcementRepository.findById(announcementId)
+				.orElseThrow(() -> new NotFoundException(NOT_FOUND_ANNOUNCEMENT));
+		if (!isAlreadyRead(memberId, announcementId)) {
+			announcementReadStatusRepository.save(AnnouncementReadStatus.record(member, announcement));
 		}
 	}
 
-	public List<Member> findReadMembers(Long announcementId) {
-		return announcementReadStatusRepository.findReadMembers(announcementId);
-	}
-
-	public List<Member> findUnReadMembers(Announcement announcement, Organization organization) {
-		Set<Long> readMemberIds = findReadMembers(announcement.getId()).stream()
-				.map(Member::getId)
-				.collect(Collectors.toSet());
-		return organization.getMembersByStatus(JoinStatus.ACTIVE).stream()
-				.filter(member -> !readMemberIds.contains(member.getId()))
-				.toList();
-	}
-
-	public Long countReader(Long announcementId) {
-		return announcementReadStatusRepository.countByAnnouncementId(announcementId);
-	}
-
-	public List<Long> getUnreadMemberIds(Long announcementId) {
-		return announcementReadStatusRepository.findUnreadMemberIds(announcementId);
-	}
-
-	public boolean isRead(Long memberId, Long announcementId) {
+	private Boolean isAlreadyRead(Long memberId, Long announcementId) {
 		return announcementReadStatusRepository.existsByMemberIdAndAnnouncementId(memberId, announcementId);
 	}
 }

--- a/src/main/java/com/notitime/noffice/domain/announcement/model/AnnouncementReadStatus.java
+++ b/src/main/java/com/notitime/noffice/domain/announcement/model/AnnouncementReadStatus.java
@@ -14,7 +14,6 @@ import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,14 +21,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"member_id", "announcement_id"})})
-@Builder
 @Getter
 public class AnnouncementReadStatus extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-
 	private Boolean isRead;
 	private LocalDateTime readAt;
 
@@ -40,4 +37,8 @@ public class AnnouncementReadStatus extends BaseTimeEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "announcement_id", nullable = false)
 	private Announcement announcement;
+
+	public static AnnouncementReadStatus record(Member member, Announcement announcement) {
+		return new AnnouncementReadStatus(null, true, LocalDateTime.now(), member, announcement);
+	}
 }

--- a/src/main/java/com/notitime/noffice/domain/announcement/persistence/AnnouncementReadStatusRepository.java
+++ b/src/main/java/com/notitime/noffice/domain/announcement/persistence/AnnouncementReadStatusRepository.java
@@ -12,16 +12,9 @@ public interface AnnouncementReadStatusRepository extends JpaRepository<Announce
 
 	boolean existsByMemberIdAndAnnouncementId(Long memberId, Long announcementId);
 
-	@Query("SELECT ars.member.id FROM AnnouncementReadStatus ars WHERE ars.announcement.id = :announcementId AND ars.isRead = false")
-	List<Long> findUnreadMemberIds(Long announcementId);
-
 	@Query("SELECT ars.member FROM AnnouncementReadStatus ars WHERE ars.announcement.id = :announcementId AND ars.isRead = true")
 	List<Member> findReadMembers(@Param("announcementId") Long announcementId);
 
 	@Query("SELECT ars.member FROM AnnouncementReadStatus ars WHERE ars.announcement.id = :announcementId AND ars.isRead = false")
 	List<Member> findUnReadMembers(@Param("announcementId") Long announcementId);
-
-	List<AnnouncementReadStatus> findByAnnouncementId(Long announcementId);
-
-	AnnouncementReadStatus findByAnnouncementIdAndMemberId(Long announcementId, Long memberId);
 }

--- a/src/main/java/com/notitime/noffice/external/firebase/FcmService.java
+++ b/src/main/java/com/notitime/noffice/external/firebase/FcmService.java
@@ -87,13 +87,8 @@ public class FcmService {
 		Organization organization = announcementRepository.findById(announcementId)
 				.orElseThrow(() -> new NotFoundException(BusinessErrorCode.NOT_FOUND_ANNOUNCEMENT))
 				.getOrganization();
-		roleVerifier.verifyLeader(leaderId, organization.getId());
-		List<Long> unreadMemberIds = announcementReadStatusRepository.findUnReadMembers(announcementId).stream()
-				.map(Member::getId)
-				.toList();
-		List<String> unreadMemberTokens = unreadMemberIds.stream()
-				.map(this::getMemberTokens)
-				.flatMap(List::stream)
+		List<String> unreadMemberTokens = announcementReadStatusRepository.findUnReadMembers(announcementId).stream()
+				.flatMap(member -> getMemberTokens(member.getId()).stream())
 				.toList();
 		String title = parseSlicedOrganizationName(organization) + " 미열람자 알림";
 		String content = "관리자가 공지 확인을 요청했어요.";


### PR DESCRIPTION
## 🚀 Related Issue

close: #168 

## 📌 Tasks

- 미열람자 대상 사용자 조회 쿼리 적용
- 열람자 관련 기능의 권한 검증 로직 중복 제외
- 미열람자 대상 FCM 알림 토큰 수집 로직 개선 (단일 스트림 병합)
 

## 📝 Details

- 게시글 조회 및 발행 과정에서 유저의 접근 권한이 검증된 상태이므로, 중복 검증을 제외  

## 📚 Remarks
- 서비스 내 조직별 권한 검증 객체를 Aspect로 취급하여 로직 외부로 위임 가능