### PR TITLE
:recycle: [Refactor] 미열람 계정 조회시 공지 객체를 별도 조회하지 않도록 변경

### DIFF
--- a/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
+++ b/src/main/java/com/notitime/noffice/api/announcement/business/AnnouncementService.java
@@ -95,12 +95,10 @@ public class AnnouncementService {
 	}
 
 	public ReadStatusResponse getUnreadMembers(Long memberId, Long announcementId) {
-		Announcement announcement = announcementRepository.findById(announcementId)
-				.orElseThrow(() -> new NotFoundException(NOT_FOUND_ANNOUNCEMENT));
-		List<Member> unreadMembers = announcementReadStatusRepository.findUnReadMembers(announcement.getId());
-		return ReadStatusResponse.of(announcementId, unreadMembers.stream()
-				.map(MemberInfoResponse::from)
-				.toList());
+		List<MemberInfoResponse> unreadMembers = announcementReadStatusRepository.findUnReadMembers(announcementId)
+				.stream().map(MemberInfoResponse::from)
+				.toList();
+		return ReadStatusResponse.of(announcementId, unreadMembers);
 	}
 
 	private Announcement createEntity(AnnouncementCreateRequest request) {


### PR DESCRIPTION
## 🚀 Related Issue

close: #

## 📌 Tasks

- 미열람 계정 조회시 공지 객체를 별도 조회하지 않도록 변경

## 📝 Details

- 해당 로직은 열람여부 기록 테이블만 관여하므로 root entity 조회를 진행하지 않습니다.

## 📚 Remarks

- 
- 