### PR TITLE
:sparkles: [Feat] 계정별 사용자명 수정 기능

### DIFF
--- a/src/main/java/com/notitime/noffice/api/member/business/MemberService.java
+++ b/src/main/java/com/notitime/noffice/api/member/business/MemberService.java
@@ -1,5 +1,6 @@
 package com.notitime.noffice.api.member.business;
 
+import com.notitime.noffice.api.member.presentation.dto.request.MemberNameUpdateRequest;
 import com.notitime.noffice.api.member.presentation.dto.request.MemberProfileUpdateRequest;
 import com.notitime.noffice.api.member.presentation.dto.response.MemberResponse;
 import com.notitime.noffice.domain.member.model.Member;
@@ -27,6 +28,12 @@ public class MemberService {
 		memberRepository.save(member);
 	}
 
+	public void updateName(Long memberId, MemberNameUpdateRequest request) {
+		Member member = findById(memberId);
+		member.updateName(request.name());
+		memberRepository.save(member);
+	}
+	
 	public void updateProfileImage(Long memberId, MemberProfileUpdateRequest request) {
 		Member member = findById(memberId);
 		member.updateProfileImage(request.imageUrl());

--- a/src/main/java/com/notitime/noffice/api/member/presentation/MemberApi.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/MemberApi.java
@@ -90,5 +90,4 @@ interface MemberApi {
 	})
 	NofficeResponse<Void> updateName(@Parameter(hidden = true) @AuthMember final Long memberId,
 	                                 @RequestBody final MemberNameUpdateRequest request);
-	}
 }

--- a/src/main/java/com/notitime/noffice/api/member/presentation/MemberApi.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/MemberApi.java
@@ -4,6 +4,7 @@ import com.notitime.noffice.api.auth.presentation.dto.request.SocialAuthRequest;
 import com.notitime.noffice.api.auth.presentation.dto.response.SocialAuthResponse;
 import com.notitime.noffice.api.auth.presentation.dto.response.TokenResponse;
 import com.notitime.noffice.api.member.presentation.dto.request.MemberAliasUpdateRequest;
+import com.notitime.noffice.api.member.presentation.dto.request.MemberNameUpdateRequest;
 import com.notitime.noffice.api.member.presentation.dto.request.MemberProfileUpdateRequest;
 import com.notitime.noffice.api.member.presentation.dto.response.MemberResponse;
 import com.notitime.noffice.auth.AuthMember;
@@ -80,4 +81,14 @@ interface MemberApi {
 	})
 	NofficeResponse<Void> updateMemberProfile(@Parameter(hidden = true) @AuthMember final Long memberId,
 	                                          @RequestBody final MemberProfileUpdateRequest request);
+
+	@Operation(summary = "[인증] 회원 이름 변경", description = "회원의 이름을 변경합니다.", responses = {
+			@ApiResponse(responseCode = "204", description = "회원 이름 변경에 성공하였습니다."),
+			@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다. 토큰을 확인해주세요.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "403", description = "요청을 수행할 수 있는 권한이 없습니다.", content = @Content(schema = @Schema(implementation = NofficeResponse.class))),
+			@ApiResponse(responseCode = "500", description = "서버 내부 에러 발생", content = @Content(schema = @Schema(implementation = NofficeResponse.class)))
+	})
+	NofficeResponse<Void> updateName(@Parameter(hidden = true) @AuthMember final Long memberId,
+	                                 @RequestBody final MemberNameUpdateRequest request);
+	}
 }

--- a/src/main/java/com/notitime/noffice/api/member/presentation/MemberController.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/MemberController.java
@@ -3,6 +3,7 @@ package com.notitime.noffice.api.member.presentation;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.DELETE_PROFILE_IMAGE_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.GET_MEMBER_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.PATCH_UPDATE_ALIAS_SUCCESS;
+import static com.notitime.noffice.global.web.BusinessSuccessCode.PATCH_UPDATE_NAME_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.PATCH_UPDATE_PROFILE_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.POST_LOGIN_SUCCESS;
 import static com.notitime.noffice.global.web.BusinessSuccessCode.POST_LOGOUT_SUCCESS;
@@ -15,6 +16,7 @@ import com.notitime.noffice.api.auth.presentation.dto.response.SocialAuthRespons
 import com.notitime.noffice.api.auth.presentation.dto.response.TokenResponse;
 import com.notitime.noffice.api.member.business.MemberService;
 import com.notitime.noffice.api.member.presentation.dto.request.MemberAliasUpdateRequest;
+import com.notitime.noffice.api.member.presentation.dto.request.MemberNameUpdateRequest;
 import com.notitime.noffice.api.member.presentation.dto.request.MemberProfileUpdateRequest;
 import com.notitime.noffice.api.member.presentation.dto.response.MemberResponse;
 import com.notitime.noffice.api.notification.business.NotificationService;
@@ -73,6 +75,13 @@ public class MemberController implements MemberApi {
 	public NofficeResponse<Void> updateAlias(@AuthMember final Long memberId,
 	                                         @RequestBody final MemberAliasUpdateRequest alias) {
 		return NofficeResponse.success(PATCH_UPDATE_ALIAS_SUCCESS);
+	}
+
+	@PatchMapping("/name")
+	public NofficeResponse<Void> updateName(@AuthMember final Long memberId,
+	                                        @RequestBody final MemberNameUpdateRequest request) {
+		memberService.updateName(memberId, request);
+		return NofficeResponse.success(PATCH_UPDATE_NAME_SUCCESS);
 	}
 
 	@PatchMapping("/profile-image")

--- a/src/main/java/com/notitime/noffice/api/member/presentation/dto/request/MemberNameUpdateRequest.java
+++ b/src/main/java/com/notitime/noffice/api/member/presentation/dto/request/MemberNameUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.notitime.noffice.api.member.presentation.dto.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MemberNameUpdateRequest(
+		@Schema(description = "사용자가 변경하려는 이름", example = "변경될 이름", requiredMode = REQUIRED)
+		String name
+) {
+}
+

--- a/src/main/java/com/notitime/noffice/domain/member/model/Member.java
+++ b/src/main/java/com/notitime/noffice/domain/member/model/Member.java
@@ -93,6 +93,10 @@ public class Member extends BaseTimeEntity {
 		this.profileImage = null;
 	}
 
+	public void updateName(String name) {
+		this.name = name;
+	}
+	
 	public void updateProfileImage(String imageUrl) {
 		this.profileImage = imageUrl;
 	}

--- a/src/main/java/com/notitime/noffice/global/web/BusinessSuccessCode.java
+++ b/src/main/java/com/notitime/noffice/global/web/BusinessSuccessCode.java
@@ -58,6 +58,7 @@ public enum BusinessSuccessCode implements SuccessCode {
 	PATCH_UPDATE_TASK_STATUS_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2404", "사용자 투두 리스트 업데이트 성공"),
 	PATCH_UPDATE_ALIAS_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2405", "[비활성화 대상] 회원 별명 변경 성공"),
 	PATCH_UPDATE_PROFILE_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2406", "프로필 이미지 주소 변경 성공"),
+	PATCH_UPDATE_NAME_SUCCESS(HttpStatus.NO_CONTENT, "NOF-2407", "회원 이름 변경 성공"),
 
 	// RESET CONTENT (2500 ~ 2599)
 	RESET_CONTENT(HttpStatus.RESET_CONTENT, "NOF-205", "리소스가 갱신되었습니다. - 205");


### PR DESCRIPTION
## 🚀 Related Issue

close: #

## 📌 Tasks

- 계정별 등록된 사용자명을 변경하는 기능을 API 배포합니다.

## 📝 Details

- OAuth 공급자별 사용자명을 얻을 수 없는 경우 존재
 - 예외 분기에 따른 사용자명 수동 입력에 따른 기능 

## 📚 Remarks

- 사용자 실명 획득 (개인정보 동의 규약에 따른 flow 정의 요구됨)
- Provider별 사용자명 페이로드 규격 통일 (Apple - Google 간 통합 요구)